### PR TITLE
Build Niagawan Inventory page (reorder worklist + web-editable watchlist)

### DIFF
--- a/src/app/niagawan/inventory/page.tsx
+++ b/src/app/niagawan/inventory/page.tsx
@@ -1,10 +1,393 @@
 // src/app/niagawan/inventory/page.tsx
 'use client';
 
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+type Watch = { code: string; description: string | null; min_balance: number; category: string | null };
+type Bal = { code: string; balance: number | null; suppliers: number | null; checked_at: string | null; updated_at: string | null };
+
+type Row = {
+  code: string;
+  description: string;
+  category: string;
+  min: number;
+  balance: number | null;
+  suppliers: number | null;
+  updated_at: string | null;
+  status: 'low' | 'ok' | 'unsure';
+};
+
+const CAT_ORDER = ['Oil - Mannol', 'Oil - Liquimoly', 'Oil - Gulf', 'Oil - Shell', 'Proton X70', 'Proton X50', 'Proton S70', 'Other'];
+const CATS = [...CAT_ORDER];
+
+function catRank(c: string) {
+  const i = CAT_ORDER.indexOf(c);
+  return i < 0 ? CAT_ORDER.length : i;
+}
+
 export default function NiagawanInventoryPage() {
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [watch, setWatch] = useState<Watch[]>([]);
+  const [bals, setBals] = useState<Bal[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'low' | 'all'>('low');
+  const [showReview, setShowReview] = useState(false);
+  const [showManage, setShowManage] = useState(false);
+
+  // check-stock-now
+  const [sync, setSync] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
+  const [syncMsg, setSyncMsg] = useState('');
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // manage watchlist
+  const [search, setSearch] = useState('');
+  const [nCode, setNCode] = useState('');
+  const [nDesc, setNDesc] = useState('');
+  const [nMin, setNMin] = useState('4');
+  const [nCat, setNCat] = useState('Other');
+  const [editCode, setEditCode] = useState<string | null>(null);
+  const [eDesc, setEDesc] = useState('');
+  const [eMin, setEMin] = useState('4');
+  const [eCat, setECat] = useState('Other');
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      setAuthed(!!data.session);
+      if (data.session?.user) {
+        const { data: ok } = await supabase.rpc('is_admin');
+        setIsAdmin(ok === true);
+      } else setIsAdmin(false);
+    })();
+  }, []);
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    const [w, b] = await Promise.all([
+      supabase.from('niagawan_min_stock').select('code,description,min_balance,category'),
+      supabase.from('niagawan_inventory').select('code,balance,suppliers,checked_at,updated_at'),
+    ]);
+    if (w.error) setErr(w.error.message);
+    else setWatch((w.data ?? []) as Watch[]);
+    setBals((b.data ?? []) as Bal[]);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    loadAll();
+  }, [isAdmin, loadAll]);
+
+  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
+
+  const balByCode = useMemo(() => {
+    const m = new Map<string, Bal>();
+    for (const b of bals) m.set(b.code, b);
+    return m;
+  }, [bals]);
+
+  const rows: Row[] = useMemo(() => {
+    return watch.map((w) => {
+      const b = balByCode.get(w.code);
+      const balance = b && b.balance != null ? Number(b.balance) : null;
+      let status: Row['status'];
+      if (balance == null) status = 'unsure';
+      else if (balance <= (w.min_balance || 0)) status = 'low';
+      else status = 'ok';
+      return {
+        code: w.code,
+        description: w.description || '',
+        category: w.category || 'Other',
+        min: w.min_balance || 0,
+        balance,
+        suppliers: b?.suppliers ?? null,
+        updated_at: b?.updated_at ?? null,
+        status,
+      };
+    });
+  }, [watch, balByCode]);
+
+  const lastChecked = useMemo(() => {
+    let t: string | null = null;
+    for (const b of bals) if (b.updated_at && (!t || b.updated_at > t)) t = b.updated_at;
+    return t ? new Date(t).toLocaleString('en-MY') : '—';
+  }, [bals]);
+
+  const stats = useMemo(() => {
+    const low = rows.filter((r) => r.status === 'low');
+    const unsure = rows.filter((r) => r.status === 'unsure');
+    const cats = new Set(low.map((r) => r.category));
+    return { low: low.length, unsure: unsure.length, cats: cats.size, total: rows.length };
+  }, [rows]);
+
+  const groups = useMemo(() => {
+    const visible = rows.filter((r) => r.status !== 'unsure' && (filter === 'all' || r.status === 'low'));
+    const byCat = new Map<string, Row[]>();
+    for (const r of visible) {
+      if (!byCat.has(r.category)) byCat.set(r.category, []);
+      byCat.get(r.category)!.push(r);
+    }
+    const cats = Array.from(byCat.keys()).sort((a, b) => catRank(a) - catRank(b) || a.localeCompare(b));
+    return cats.map((cat) => {
+      const items = byCat.get(cat)!;
+      items.sort((a, b) => {
+        const al = a.status === 'low' ? 0 : 1, bl = b.status === 'low' ? 0 : 1;
+        if (al !== bl) return al - bl;
+        return a.code.localeCompare(b.code);
+      });
+      const lowCount = items.filter((r) => r.status === 'low').length;
+      return { cat, items, lowCount };
+    });
+  }, [rows, filter]);
+
+  const review = useMemo(() => rows.filter((r) => r.status === 'unsure'), [rows]);
+
+  const filteredWatch = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const list = q
+      ? watch.filter((w) => w.code.toLowerCase().includes(q) || (w.description || '').toLowerCase().includes(q))
+      : watch;
+    return [...list].sort((a, b) => catRank(a.category || 'Other') - catRank(b.category || 'Other') || a.code.localeCompare(b.code));
+  }, [watch, search]);
+
+  const checkStockNow = useCallback(async () => {
+    if (sync === 'running') return;
+    setSync('running');
+    setSyncMsg('Starting stock check…');
+    const { data, error } = await supabase
+      .from('sync_requests').insert({ source: 'website-inventory', which: 'inventory' }).select('id').single();
+    if (error || !data) { setSync('error'); setSyncMsg('Could not start: ' + (error?.message ?? 'unknown')); return; }
+    const id = data.id as number;
+    setSyncMsg('Checking live stock in Niagawan… ~1–2 min. You can leave this page.');
+    const started = Date.now();
+    pollRef.current = setInterval(async () => {
+      const { data: r } = await supabase.from('sync_requests').select('status').eq('id', id).single();
+      if (r?.status === 'done' || r?.status === 'error') {
+        if (pollRef.current) clearInterval(pollRef.current);
+        await loadAll();
+        setSync(r.status === 'done' ? 'done' : 'error');
+        setSyncMsg(r.status === 'done' ? 'Stock updated ✓' : 'Check ran but reported an error.');
+        setTimeout(() => { setSync('idle'); setSyncMsg(''); }, 5000);
+      } else if (Date.now() - started > 5 * 60 * 1000) {
+        if (pollRef.current) clearInterval(pollRef.current);
+        setSync('idle');
+        setSyncMsg('Still running in the background — refresh in a bit.');
+      }
+    }, 4000);
+  }, [sync, loadAll]);
+
+  const addItem = useCallback(async () => {
+    const code = nCode.trim();
+    if (!code) return;
+    const { error } = await supabase.from('niagawan_min_stock').insert({
+      code, description: nDesc.trim() || null, min_balance: Number(nMin) || 4, category: nCat,
+    });
+    if (!error) { setNCode(''); setNDesc(''); setNMin('4'); setNCat('Other'); await loadAll(); }
+    else setErr(error.message);
+  }, [nCode, nDesc, nMin, nCat, loadAll]);
+
+  const startEdit = useCallback((w: Watch) => {
+    setEditCode(w.code); setEDesc(w.description || ''); setEMin(String(w.min_balance || 4)); setECat(w.category || 'Other');
+  }, []);
+  const saveEdit = useCallback(async () => {
+    if (!editCode) return;
+    await supabase.from('niagawan_min_stock')
+      .update({ description: eDesc.trim() || null, min_balance: Number(eMin) || 4, category: eCat, updated_at: new Date().toISOString() })
+      .eq('code', editCode);
+    setEditCode(null);
+    await loadAll();
+  }, [editCode, eDesc, eMin, eCat, loadAll]);
+  const deleteItem = useCallback(async (code: string) => {
+    await supabase.from('niagawan_min_stock').delete().eq('code', code);
+    await loadAll();
+  }, [loadAll]);
+
+  if (authed === null || isAdmin === null) return <div className="text-sm text-gray-500">Checking session…</div>;
+  if (authed === false) return <div className="text-sm text-gray-600">Please sign in to view this page.</div>;
+  if (!isAdmin) return <div className="text-sm text-gray-600">This page is for admins only.</div>;
+
   return (
-    <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-sm text-gray-500">
-      Inventory view — coming next (current stock vs minimum, low items highlighted).
+    <div>
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-gray-700">Reorder list</h2>
+          <div className="flex overflow-hidden rounded-md border border-gray-300 text-xs">
+            <button onClick={() => setFilter('low')} className={`px-2 py-1 ${filter === 'low' ? 'bg-gray-900 text-white' : 'bg-white text-gray-600'}`}>Low only</button>
+            <button onClick={() => setFilter('all')} className={`px-2 py-1 ${filter === 'all' ? 'bg-gray-900 text-white' : 'bg-white text-gray-600'}`}>All</button>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-gray-400">Last checked: {lastChecked}</span>
+          <button onClick={checkStockNow} disabled={sync === 'running'}
+            className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition ${sync === 'running' ? 'cursor-not-allowed bg-gray-100 text-gray-400' : 'bg-blue-600 text-white hover:bg-blue-700'}`}>
+            {sync === 'running' ? (<><span className="h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-gray-500" />Checking…</>) : 'Check stock now'}
+          </button>
+        </div>
+      </div>
+
+      {syncMsg && (
+        <div className={`mb-3 rounded border p-2 text-xs ${sync === 'error' ? 'border-rose-200 bg-rose-50 text-rose-700' : sync === 'done' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-blue-200 bg-blue-50 text-blue-700'}`}>{syncMsg}</div>
+      )}
+
+      <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+          <div className="text-xs font-medium text-gray-500">Low items</div>
+          <div className="mt-1 text-lg font-semibold text-rose-600">{stats.low}</div>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+          <div className="text-xs font-medium text-gray-500">Categories affected</div>
+          <div className="mt-1 text-lg font-semibold text-gray-900">{stats.cats}</div>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+          <div className="text-xs font-medium text-gray-500">Needs review</div>
+          <div className="mt-1 text-lg font-semibold text-amber-600">{stats.unsure}</div>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+          <div className="text-xs font-medium text-gray-500">Items watched</div>
+          <div className="mt-1 text-lg font-semibold text-gray-900">{stats.total}</div>
+        </div>
+      </div>
+
+      {err && <div className="mb-4 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">{err}</div>}
+
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading…</div>
+      ) : groups.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-sm text-gray-500">
+          {filter === 'low' ? 'Nothing low right now — everything is above its minimum. 🎉' : 'No stock data yet. Tap “Check stock now”.'}
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {groups.map((g) => (
+            <div key={g.cat} className="overflow-hidden rounded-lg border border-gray-200">
+              <div className="flex items-center justify-between bg-blue-50 px-3 py-2 text-sm font-semibold text-gray-800">
+                <span>{g.cat}</span>
+                <span className="text-xs font-medium text-gray-500">{g.items.length} item{g.items.length !== 1 ? 's' : ''}, {g.lowCount} low</span>
+              </div>
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead className="bg-gray-50">
+                  <tr className="text-left">
+                    <th className="px-3 py-2 font-semibold text-gray-700">Code</th>
+                    <th className="px-3 py-2 font-semibold text-gray-700">Description</th>
+                    <th className="px-3 py-2 text-right font-semibold text-gray-700">Balance</th>
+                    <th className="px-3 py-2 text-right font-semibold text-gray-700">Min</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 bg-white">
+                  {g.items.map((r) => (
+                    <tr key={r.code} className={r.status === 'low' ? 'bg-rose-50' : ''}>
+                      <td className="whitespace-nowrap px-3 py-2 font-medium text-gray-900">{r.code}</td>
+                      <td className="px-3 py-2 text-gray-700">{r.description}</td>
+                      <td className={`whitespace-nowrap px-3 py-2 text-right font-medium ${r.status === 'low' ? 'text-rose-600' : 'text-gray-900'}`}>{r.balance}</td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right text-gray-500">{r.min}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Needs review (unsure) */}
+      {review.length > 0 && (
+        <div className="mt-5">
+          <button onClick={() => setShowReview((s) => !s)} className="text-xs font-medium text-amber-700 underline hover:text-amber-900">
+            {showReview ? 'Hide' : 'Show'} {review.length} item(s) needing review (stock couldn’t be read)
+          </button>
+          {showReview && (
+            <div className="mt-2 overflow-x-auto rounded-lg border border-amber-200">
+              <table className="min-w-full divide-y divide-amber-100 text-sm">
+                <tbody className="divide-y divide-amber-50 bg-amber-50/40">
+                  {review.map((r) => (
+                    <tr key={r.code} className="text-gray-600">
+                      <td className="whitespace-nowrap px-3 py-1.5 font-medium">{r.code}</td>
+                      <td className="px-3 py-1.5">{r.description}</td>
+                      <td className="whitespace-nowrap px-3 py-1.5 text-gray-400">{r.category}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Manage watchlist */}
+      <div className="mt-6">
+        <button onClick={() => setShowManage((s) => !s)} className="text-xs font-medium text-gray-500 underline hover:text-gray-700">
+          {showManage ? 'Hide' : 'Manage'} watchlist ({watch.length} items)
+        </button>
+        {showManage && (
+          <div className="mt-2 rounded-lg border border-gray-200 bg-white p-3">
+            <p className="mb-3 text-xs text-gray-500">Items the scraper checks each run. Add, edit the min level / category, or remove. Changes take effect on the next stock check.</p>
+
+            {/* Add */}
+            <div className="mb-3 flex flex-wrap items-end gap-2 rounded-md bg-gray-50 p-2">
+              <label className="text-xs text-gray-600">Code<input value={nCode} onChange={(e) => setNCode(e.target.value)} placeholder="e.g. MN7501-4" className="mt-1 block w-32 rounded-md border border-gray-300 px-2 py-1 text-xs" /></label>
+              <label className="text-xs text-gray-600">Description<input value={nDesc} onChange={(e) => setNDesc(e.target.value)} className="mt-1 block w-56 rounded-md border border-gray-300 px-2 py-1 text-xs" /></label>
+              <label className="text-xs text-gray-600">Min<input value={nMin} onChange={(e) => setNMin(e.target.value)} className="mt-1 block w-14 rounded-md border border-gray-300 px-2 py-1 text-xs" /></label>
+              <label className="text-xs text-gray-600">Category
+                <select value={nCat} onChange={(e) => setNCat(e.target.value)} className="mt-1 block rounded-md border border-gray-300 px-2 py-1 text-xs">
+                  {CATS.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </label>
+              <button onClick={addItem} disabled={!nCode.trim()} className="rounded-md bg-gray-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-gray-700 disabled:opacity-40">Add item</button>
+            </div>
+
+            <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search code or description…" className="mb-2 w-full rounded-md border border-gray-300 px-2 py-1 text-xs" />
+
+            <div className="max-h-96 overflow-y-auto rounded-md border border-gray-100">
+              <table className="min-w-full divide-y divide-gray-100 text-xs">
+                <thead className="sticky top-0 bg-gray-50 text-left text-gray-500">
+                  <tr>
+                    <th className="px-2 py-1 font-semibold">Code</th>
+                    <th className="px-2 py-1 font-semibold">Description</th>
+                    <th className="px-2 py-1 font-semibold">Min</th>
+                    <th className="px-2 py-1 font-semibold">Category</th>
+                    <th className="px-2 py-1"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-50">
+                  {filteredWatch.map((w) =>
+                    editCode === w.code ? (
+                      <tr key={w.code} className="bg-amber-50">
+                        <td className="whitespace-nowrap px-2 py-1 font-medium text-gray-900">{w.code}</td>
+                        <td className="px-2 py-1"><input value={eDesc} onChange={(e) => setEDesc(e.target.value)} className="w-full rounded border border-gray-300 px-1 py-0.5" /></td>
+                        <td className="px-2 py-1"><input value={eMin} onChange={(e) => setEMin(e.target.value)} className="w-12 rounded border border-gray-300 px-1 py-0.5" /></td>
+                        <td className="px-2 py-1">
+                          <select value={eCat} onChange={(e) => setECat(e.target.value)} className="rounded border border-gray-300 px-1 py-0.5">
+                            {CATS.map((c) => <option key={c} value={c}>{c}</option>)}
+                          </select>
+                        </td>
+                        <td className="whitespace-nowrap px-2 py-1 text-right">
+                          <button onClick={saveEdit} className="mr-1 rounded-md border border-emerald-200 px-2 py-0.5 text-emerald-700 hover:bg-emerald-50">Save</button>
+                          <button onClick={() => setEditCode(null)} className="rounded-md border border-gray-200 px-2 py-0.5 text-gray-500 hover:bg-gray-100">Cancel</button>
+                        </td>
+                      </tr>
+                    ) : (
+                      <tr key={w.code}>
+                        <td className="whitespace-nowrap px-2 py-1 font-medium text-gray-900">{w.code}</td>
+                        <td className="px-2 py-1 text-gray-700">{w.description}</td>
+                        <td className="px-2 py-1 text-gray-500">{w.min_balance}</td>
+                        <td className="whitespace-nowrap px-2 py-1 text-gray-500">{w.category}</td>
+                        <td className="whitespace-nowrap px-2 py-1 text-right">
+                          <button onClick={() => startEdit(w)} className="mr-1 rounded-md border border-gray-200 px-2 py-0.5 text-gray-600 hover:bg-gray-100">Edit</button>
+                          <button onClick={() => deleteItem(w.code)} className="rounded-md border border-gray-200 px-2 py-0.5 text-rose-600 hover:bg-rose-50">Delete</button>
+                        </td>
+                      </tr>
+                    )
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Last placeholder, now built — a **reorder worklist** with a **web-editable Min Stock watchlist**.

## Page
- **Reorder list** grouped by category/supplier, low items (balance ≤ min) flagged red; **Low only / All** toggle. Mirrors your sheet's `categoryOf_` grouping + low logic.
- **Check stock now** — queues a `which=inventory` sync; the NAS poller runs the scraper and balances refresh (~1–2 min).
- **Needs review** — items the scraper couldn't read confidently (null balance).
- **Manage watchlist** — add / edit (min level, category, description) / delete, with search. This is now the **source of truth** the scraper reads.

## Backend (already deployed)
- `niagawan_min_stock` (watchlist, admin RLS, seeded with your 255 items + derived categories) and `niagawan_inventory` (balances).
- `niagawan-inventory` edge function: getWatchlist / seedWatchlist / putBalances (token-auth).
- Scraper reads the watchlist from Supabase and pushes balances there (still writes the legacy sheet too).

Verified: live scrape pushed 255 items (251 balances, 4 unsure), ~184 low. Type-check passes.