### PR TITLE
Fix: make payslips private (close public exposure)

### DIFF
--- a/src/app/api/payroll/finalize/route.ts
+++ b/src/app/api/payroll/finalize/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { createClientServer } from '@/lib/supabaseServer';
 // @ts-ignore  // types provided by src/types/pdfkit-standalone.d.ts
 import PDFDocument from 'pdfkit/js/pdfkit.standalone.js';
 
@@ -179,17 +180,36 @@ async function uploadToStorage(path: string, bytes: Buffer, contentType = 'appli
     contentType,
   });
   if (error) throw new Error(error.message);
-  const { data: pub } = supabaseAdmin.storage.from('payroll').getPublicUrl(path);
-  return pub.publicUrl;
+  // Bucket is PRIVATE — return a short-lived signed URL instead of a public one.
+  const { data: signed, error: sErr } = await supabaseAdmin.storage
+    .from('payroll')
+    .createSignedUrl(path, 60 * 60); // 1 hour
+  if (sErr || !signed) throw new Error(sErr?.message || 'could not sign url');
+  return signed.signedUrl;
 }
 
-export async function GET(req: Request) {
+export async function POST(req: Request) {
   try {
+    // --- admin gate: this route uses the service-role key, so it MUST verify the caller ---
+    const token = (req.headers.get('authorization') || '').replace(/^Bearer\s+/i, '').trim();
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const sb = createClientServer(req);
+    const { data: auth, error: authErr } = await sb.auth.getUser(token);
+    if (authErr || !auth?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const { data: isAdmin } = await sb.rpc('is_admin');
+    if (isAdmin !== true) {
+      return NextResponse.json({ error: 'Forbidden — admins only' }, { status: 403 });
+    }
+
     const { searchParams } = new URL(req.url);
     const year = Number(searchParams.get('year'));
     const month = Number(searchParams.get('month'));
-    if (!year || !month) {
-      return NextResponse.json({ error: 'year & month required' }, { status: 400 });
+    if (!Number.isInteger(year) || year < 2000 || year > 2100 || !Number.isInteger(month) || month < 1 || month > 12) {
+      return NextResponse.json({ error: 'valid year & month required' }, { status: 400 });
     }
 
     const period = await fetchPeriod(year, month);
@@ -218,7 +238,7 @@ export async function GET(req: Request) {
       payslipResults.push({ email, url });
     }
 
-    await supabaseAdmin.rpc('pay_v2.finalize_period', { p_year: year, p_month: month });
+    await supabaseAdmin.schema('pay_v2').rpc('finalize_period', { p_year: year, p_month: month });
 
     return NextResponse.json({ summaryUrl, payslips: payslipResults }, { status: 200 });
   } catch (e: any) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -5,7 +5,9 @@ import { createClientServer } from '@/lib/supabaseServer'
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const code = url.searchParams.get('code')
-  const next = url.searchParams.get('next') || '/'
+  // Only allow same-site relative paths, to prevent an open-redirect via ?next=
+  const nextRaw = url.searchParams.get('next') || '/'
+  const next = nextRaw.startsWith('/') && !nextRaw.startsWith('//') ? nextRaw : '/'
 
   // Server-side Supabase client; handles cookies internally
   const supabase = createClientServer(req)

--- a/src/app/payroll/records/page.tsx
+++ b/src/app/payroll/records/page.tsx
@@ -149,8 +149,10 @@ export default function PayrollRecordsPage() {
       if (lsSErr) throw lsSErr;
       const hasSummary = (lsSummary ?? []).some((f) => f.name === summaryName);
       if (hasSummary) {
-        const { data: pub } = supabase.storage.from('payroll').getPublicUrl(`${basePath}/${summaryName}`);
-        setSummaryUrl(pub.publicUrl);
+        const { data: signed } = await supabase.storage
+          .from('payroll')
+          .createSignedUrl(`${basePath}/${summaryName}`, 3600);
+        setSummaryUrl(signed?.signedUrl ?? null);
       } else {
         setSummaryUrl(null);
       }
@@ -162,10 +164,14 @@ export default function PayrollRecordsPage() {
       if (lsErr) throw lsErr;
 
       const files = (ls ?? []).filter((f) => f.name.toLowerCase().endsWith('.pdf'));
-      const withUrls: PayslipFile[] = files.map((f) => {
-        const { data: pub } = supabase.storage.from('payroll').getPublicUrl(`${basePath}/payslips/${f.name}`);
-        return { name: f.name, url: pub.publicUrl };
-      });
+      const withUrls: PayslipFile[] = await Promise.all(
+        files.map(async (f) => {
+          const { data: signed } = await supabase.storage
+            .from('payroll')
+            .createSignedUrl(`${basePath}/payslips/${f.name}`, 3600);
+          return { name: f.name, url: signed?.signedUrl ?? '' };
+        })
+      );
       setPayslips(withUrls);
       setFinMsg(null);
     } catch (e: any) {
@@ -192,7 +198,12 @@ export default function PayrollRecordsPage() {
     setFinMsg('Generating PDFs & finalizing…');
     try {
       const qs = new URLSearchParams({ year: String(year), month: String(month) }).toString();
-      const res = await fetch(`/api/payroll/finalize?${qs}`, { method: 'POST' });
+      const { data: sess } = await supabase.auth.getSession();
+      const token = sess.session?.access_token;
+      const res = await fetch(`/api/payroll/finalize?${qs}`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
       const json = await res.json();
       if (!res.ok) throw new Error(json?.error || 'Failed to finalize');
 


### PR DESCRIPTION
Closes a confirmed data exposure: payslip PDFs (public bucket + predictable paths) and salary tables (anon-readable RLS) were publicly accessible. Bucket is now private with admin-only access + signed URLs; finalize is admin-guarded (POST + JWT) and no longer leaks public URLs; open-redirect in auth callback fixed. Admin download workflow preserved via signed URLs. Type-check passes; DB migration already applied.