### PR TITLE
Fix: Today v2 board was empty (grant/view issue)

### DIFF
--- a/src/app/attendance/today/page.tsx
+++ b/src/app/attendance/today/page.tsx
@@ -58,10 +58,7 @@ export default function AttendanceTodayPage() {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const { data, error } = await supabase
-      .from('v2_today')
-      .select('*')
-      .order('display_name', { ascending: true });
+    const { data, error } = await supabase.rpc('attendance_today_v2');
     if (!error) {
       setRows((data ?? []) as Row[]);
       setUpdated(


### PR DESCRIPTION
Today page read the security_invoker view v2_today but att_v2.daily isn't granted to authenticated -> empty. Now uses SECURITY DEFINER admin-gated RPC attendance_today_v2(). Type-check passes; migration applied.