### PR TITLE
Employees: permanently delete archived employee

### DIFF
--- a/src/app/api/admin/delete-employee/route.ts
+++ b/src/app/api/admin/delete-employee/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { createClientServer } from '@/lib/supabaseServer';
+
+export const runtime = 'nodejs';
+
+const admin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+);
+
+// POST { email } -> permanently delete an archived employee + all their data + login + MC files
+export async function POST(req: Request) {
+  try {
+    const token = (req.headers.get('authorization') || '').replace(/^Bearer\s+/i, '').trim();
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const sb = createClientServer(req);
+    const { data: auth, error: aErr } = await sb.auth.getUser(token);
+    if (aErr || !auth?.user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const { data: isAdmin } = await sb.rpc('is_admin');
+    if (isAdmin !== true) return NextResponse.json({ error: 'Forbidden — admins only' }, { status: 403 });
+
+    const body = await req.json();
+    const email = String(body?.email || '').trim().toLowerCase();
+    if (!email) return NextResponse.json({ error: 'email required' }, { status: 400 });
+
+    // Delete all DB rows via the admin-gated function (runs as the caller, one transaction).
+    // It enforces "must be archived first".
+    const { data: paths, error: delErr } = await sb.rpc('delete_employee_data', { p_email: email });
+    if (delErr) return NextResponse.json({ error: delErr.message }, { status: 400 });
+
+    // Remove MC certificate files from storage
+    if (Array.isArray(paths) && paths.length) {
+      try { await admin.storage.from('mc').remove(paths as string[]); } catch { /* non-fatal */ }
+    }
+
+    // Delete their login account
+    try {
+      let userId: string | null = null;
+      for (let page = 1; page <= 20 && !userId; page++) {
+        const { data, error } = await admin.auth.admin.listUsers({ page, perPage: 200 });
+        if (error) break;
+        const u = data.users.find((x) => (x.email || '').toLowerCase() === email);
+        if (u) userId = u.id;
+        if (data.users.length < 200) break;
+      }
+      if (userId) await admin.auth.admin.deleteUser(userId);
+    } catch { /* non-fatal */ }
+
+    return NextResponse.json({ ok: true });
+  } catch (e: unknown) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}

--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -98,6 +98,7 @@ export default function EmployeesPage() {
   const [rows, setRows] = useState<StaffBrief[]>([]);
   const [q, setQ] = useState('');
   const [showArchived, setShowArchived] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
   // editor
   const [openEmail, setOpenEmail] = useState<string | null>(null);
@@ -454,6 +455,35 @@ export default function EmployeesPage() {
     }
   };
 
+  const deleteEmployee = async (email: string, name: string) => {
+    const typed = window.prompt(
+      `This permanently deletes ${name} and ALL their data (attendance history, payroll, MC certificates, and login). This CANNOT be undone.\n\nType the email to confirm:\n${email}`
+    );
+    if (typed === null) return; // cancelled
+    if (typed.trim().toLowerCase() !== email.toLowerCase()) {
+      alert('Email did not match — nothing was deleted.');
+      return;
+    }
+    setDeleting(email);
+    setMsg(null);
+    try {
+      const tok = (await supabase.auth.getSession()).data.session?.access_token;
+      const res = await fetch('/api/admin/delete-employee', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(tok ? { Authorization: `Bearer ${tok}` } : {}) },
+        body: JSON.stringify({ email }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || 'Delete failed');
+      setMsg(`Permanently deleted ${name}.`);
+      await reloadList();
+    } catch (e: any) {
+      setMsg(`Delete failed: ${e.message ?? e}`);
+    } finally {
+      setDeleting(null);
+    }
+  };
+
   function closeEditor() {
     if (saving) return;
     setOpenEmail(null);
@@ -520,9 +550,20 @@ export default function EmployeesPage() {
                   <td className="border-b px-3 py-2">{r.position ?? '—'}</td>
                   <td className="border-b px-3 py-2">{r.year_join ?? (r.start_date?.slice(0, 4) ?? '—')}</td>
                   <td className="border-b px-3 py-2 text-right">
-                    <button className="rounded border px-3 py-1.5 hover:bg-gray-50" onClick={() => openEditor(r.email)}>
-                      Edit
-                    </button>
+                    <div className="flex justify-end gap-2">
+                      <button className="rounded border px-3 py-1.5 hover:bg-gray-50" onClick={() => openEditor(r.email)}>
+                        Edit
+                      </button>
+                      {showArchived && (
+                        <button
+                          className="rounded border border-rose-300 px-3 py-1.5 text-rose-700 hover:bg-rose-50 disabled:opacity-50"
+                          disabled={deleting === r.email}
+                          onClick={() => deleteEmployee(r.email, r.display_name ?? r.email)}
+                        >
+                          {deleting === r.email ? 'Deleting…' : 'Delete'}
+                        </button>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
Red Delete on archived rows with type-the-email confirm. Admin route + SECURITY DEFINER cascade (requires archived first, one transaction), removes MC files + auth login. Irreversible. Type-check passes; migration applied.