### PR TITLE
Purchase Invoice: AI read step (Stage 2)

### DIFF
--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { createClientServer } from '@/lib/supabaseServer';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const admin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+);
+
+const PROMPT =
+  'Read this supplier purchase invoice. Return ONLY JSON with this shape: ' +
+  '{"supplier_name":string,"ref_no":string,"invoice_date":"YYYY-MM-DD","total":number,' +
+  '"items":[{"item_code":string,"description":string,"qty":number,"unit_price":number,"amount":number}]}. ' +
+  'Use the EXACT item code from the Item Code column (keep spaces/brackets). Include every line item. ' +
+  'ref_no is the supplier invoice number. If a field is missing use null.';
+
+async function geminiExtract(base64: string, key: string): Promise<string> {
+  const body = JSON.stringify({
+    contents: [{ parts: [{ inline_data: { mime_type: 'application/pdf', data: base64 } }, { text: PROMPT }] }],
+    generationConfig: { responseMimeType: 'application/json' },
+  });
+  let lastErr = '';
+  for (const model of ['gemini-2.5-flash', 'gemini-2.0-flash']) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const r = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${key}`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
+      );
+      if (r.ok) {
+        const j = await r.json();
+        const text = j?.candidates?.[0]?.content?.parts?.[0]?.text;
+        if (text) return text;
+        lastErr = 'empty AI response';
+      } else {
+        lastErr = `${model} HTTP ${r.status}`;
+        if (r.status !== 503 && r.status !== 429) break;
+        await new Promise((res) => setTimeout(res, 1500));
+      }
+    }
+  }
+  throw new Error('AI read failed: ' + lastErr);
+}
+
+export async function POST(req: Request) {
+  let id: string | null = null;
+  try {
+    const token = (req.headers.get('authorization') || '').replace(/^Bearer\s+/i, '').trim();
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const sb = createClientServer(req);
+    const { data: auth, error: aErr } = await sb.auth.getUser(token);
+    if (aErr || !auth?.user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const { data: isAdmin } = await sb.rpc('is_admin');
+    if (isAdmin !== true) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    const body = await req.json();
+    id = body?.id ?? null;
+    if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 });
+
+    await admin.from('pinv').update({ status: 'extracting', updated_at: new Date().toISOString() }).eq('id', id);
+
+    const { data: row } = await admin.from('pinv').select('file_path').eq('id', id).maybeSingle();
+    if (!row?.file_path) throw new Error('No PDF on file');
+
+    const { data: blob, error: dErr } = await admin.storage.from('pinv').download(row.file_path);
+    if (dErr || !blob) throw new Error('Could not read the PDF: ' + (dErr?.message ?? ''));
+    const base64 = Buffer.from(await blob.arrayBuffer()).toString('base64');
+
+    const { data: secret } = await admin.from('app_secrets').select('value').eq('name', 'gemini_key').single();
+    if (!secret?.value) throw new Error('AI key not configured');
+
+    const text = await geminiExtract(base64, secret.value);
+    let parsed: { supplier_name?: string; ref_no?: string; invoice_date?: string; total?: number; items?: unknown[] };
+    try { parsed = JSON.parse(text); } catch { throw new Error('AI returned invalid data'); }
+    const items = Array.isArray(parsed.items) ? parsed.items : [];
+
+    await admin.from('pinv').update({
+      supplier_name: parsed.supplier_name ?? null,
+      ref_no: parsed.ref_no ?? null,
+      invoice_date: typeof parsed.invoice_date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(parsed.invoice_date) ? parsed.invoice_date : null,
+      total: Number.isFinite(Number(parsed.total)) ? Number(parsed.total) : null,
+      status: 'extracted',
+      note: null,
+      updated_at: new Date().toISOString(),
+    }).eq('id', id);
+
+    await admin.from('pinv_item').delete().eq('pinv_id', id);
+    if (items.length) {
+      const rows = items.map((raw, i) => {
+        const it = raw as { item_code?: unknown; description?: unknown; qty?: unknown; unit_price?: unknown; amount?: unknown };
+        return {
+          pinv_id: id,
+          line_no: i + 1,
+          item_code: String(it.item_code ?? '').trim() || null,
+          description: String(it.description ?? '').trim() || null,
+          qty: Number(it.qty) || 0,
+          unit_price: Number(it.unit_price) || 0,
+          amount: Number(it.amount) || 0,
+        };
+      });
+      await admin.from('pinv_item').insert(rows);
+    }
+
+    return NextResponse.json({ ok: true, items: items.length });
+  } catch (e: unknown) {
+    const m = e instanceof Error ? e.message : String(e);
+    if (id) { try { await admin.from('pinv').update({ status: 'error', note: m.slice(0, 300), updated_at: new Date().toISOString() }).eq('id', id); } catch { /* ignore */ } }
+    return NextResponse.json({ error: m }, { status: 500 });
+  }
+}

--- a/src/app/niagawan/purchase/page.tsx
+++ b/src/app/niagawan/purchase/page.tsx
@@ -34,6 +34,7 @@ export default function PurchaseInvoicePage() {
   const [loading, setLoading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [busy, setBusy] = useState(false);
+  const [readingId, setReadingId] = useState<string | null>(null);
   const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
 
   useEffect(() => {
@@ -75,6 +76,29 @@ export default function PurchaseInvoicePage() {
       setBusy(false);
     }
   }, [file, load]);
+
+  const readInvoice = useCallback(async (id: string) => {
+    setReadingId(id); setMsg(null);
+    try {
+      const { data: sess } = await supabase.auth.getSession();
+      const token = sess.session?.access_token;
+      if (!token) throw new Error('Not signed in.');
+      const res = await fetch('/api/pinv/extract', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ id }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(j?.error || `Read failed (${res.status})`);
+      setMsg({ kind: 'ok', text: `Read ✓ — found ${j.items ?? 0} line item${j.items === 1 ? '' : 's'}.` });
+      await load();
+    } catch (e: unknown) {
+      setMsg({ kind: 'err', text: e instanceof Error ? e.message : String(e) });
+      await load();
+    } finally {
+      setReadingId(null);
+    }
+  }, [load]);
 
   const viewPdf = useCallback(async (path: string | null) => {
     if (!path) return;
@@ -141,7 +165,19 @@ export default function PurchaseInvoicePage() {
                   </span>
                 </td>
                 <td className="px-3 py-2 text-right">
-                  {r.file_path && <button onClick={() => viewPdf(r.file_path)} className="rounded border border-gray-200 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-50">View PDF</button>}
+                  <div className="flex items-center justify-end gap-1.5">
+                    {(r.status === 'uploaded' || r.status === 'error') && (
+                      <button onClick={() => readInvoice(r.id)} disabled={readingId === r.id} className="rounded bg-blue-600 px-2 py-0.5 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+                        {readingId === r.id ? 'Reading…' : 'Read'}
+                      </button>
+                    )}
+                    {r.status === 'extracted' && (
+                      <button onClick={() => readInvoice(r.id)} disabled={readingId === r.id} className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-50 disabled:opacity-50">
+                        {readingId === r.id ? 'Reading…' : 'Re-read'}
+                      </button>
+                    )}
+                    {r.file_path && <button onClick={() => viewPdf(r.file_path)} className="rounded border border-gray-200 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-50">View PDF</button>}
+                  </div>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## What
Adds the **read** step to the Purchase Invoice pipeline: upload PDF -> read with AI -> review -> create in Niagawan.

## Changes
- **`POST /api/pinv/extract`** (new, admin Bearer-gated, server-side service role):
  - Downloads the PDF from the private `pinv` bucket
  - Reads `gemini_key` from `app_secrets`
  - Calls Gemini `generateContent` with the PDF inline + strict JSON prompt, retrying across `gemini-2.5-flash` -> `gemini-2.0-flash` on 503/429
  - Saves `supplier_name`, `ref_no`, `invoice_date`, `total`, and all line items into `pinv` / `pinv_item`; sets status `extracted` (or `error`)
- **Purchase page**: `Read` button on `uploaded`/`error` rows, `Re-read` on `extracted`, shows line-item count after reading.

## Verified
- Gemini extraction validated against the real Grand Auto PDF (all 26 items, exact codes).
- `tsc --noEmit` passes.
- All written columns confirmed in `pinv` / `pinv_item`.

## Next (Stage 3-4)
Review screen (edit/match items, flag items to create) -> create in Niagawan via the NAS.

Generated with Claude Code