### PR TITLE
PI read: current model fallbacks (2.0-flash retired)

### DIFF
--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -38,7 +38,13 @@ async function geminiExtract(base64: string, key: string, prompt: string): Promi
   // Each model gets a hard timeout so the whole request finishes well under Vercel's 60s
   // limit — otherwise a hanging AI call gets killed mid-run and the invoice is left stuck.
   let lastErr = '';
-  const tries: Array<[string, number]> = [['gemini-2.5-flash', 28000], ['gemini-2.0-flash', 22000]];
+  // Primary + current fallbacks (gemini-2.0-flash was retired -> 404). If the primary is
+  // overloaded (503), fall through to lighter/latest flash models that stay responsive.
+  const tries: Array<[string, number]> = [
+    ['gemini-2.5-flash', 22000],
+    ['gemini-flash-latest', 18000],
+    ['gemini-2.5-flash-lite', 14000],
+  ];
   for (const [model, timeoutMs] of tries) {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);


### PR DESCRIPTION
gemini-2.0-flash now 404s (retired). Fallback chain is now gemini-2.5-flash -> gemini-flash-latest -> gemini-2.5-flash-lite, so a 503 on the primary auto-falls-back to a responsive model.