### PR TITLE
Fix Purchase Invoice read: 3.5-flash only + progress feedback

### DIFF
--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -30,45 +30,65 @@ function buildPrompt(categoryNames: string[]): string {
   );
 }
 
+// We use ONE model — gemini-3.5-flash — because it reads part codes accurately (the old
+// gemini-2.0-flash misread e.g. HUB227->HUB2327). "thinking" is turned OFF (thinkingBudget:0):
+// for a plain read-and-extract job it adds latency without improving accuracy, so disabling it
+// makes the model fast enough to finish inside Vercel's 60s cap.
+//
+// The model itself can be transiently overloaded on Google's side (HTTP 503 / 429 / 500), which
+// shows up as the request hanging then failing. So instead of falling back to a different model,
+// we RETRY gemini-3.5-flash a few times within an overall deadline. Non-transient errors
+// (400/403/404) stop immediately — retrying those is pointless.
+const READ_MODEL = 'gemini-3.5-flash';
+
 async function geminiExtract(base64: string, key: string, prompt: string): Promise<string> {
   const body = JSON.stringify({
     contents: [{ parts: [{ inline_data: { mime_type: 'application/pdf', data: base64 } }, { text: prompt }] }],
-    generationConfig: { responseMimeType: 'application/json' },
+    generationConfig: { responseMimeType: 'application/json', thinkingConfig: { thinkingBudget: 0 } },
   });
-  // Each model gets a hard timeout so the whole request finishes well under Vercel's 60s
-  // limit — otherwise a hanging AI call gets killed mid-run and the invoice is left stuck.
+  const OVERALL_MS = 52000; // stay safely under Vercel's 60s function cap
+  const ATTEMPT_MS = 26000; // per-attempt hard timeout
+  const start = Date.now();
   let lastErr = '';
-  // Use accurate, current flash models. The old fallback gemini-2.0-flash both misread codes
-  // (e.g. HUB227->HUB2327) and was retired (404). gemini-3.5-flash / gemini-flash-latest read
-  // codes correctly in testing and stay responsive when gemini-2.5-flash is overloaded (503).
-  const tries: Array<[string, number]> = [
-    ['gemini-3.5-flash', 22000],
-    ['gemini-flash-latest', 18000],
-    ['gemini-2.5-flash', 14000],
-  ];
-  for (const [model, timeoutMs] of tries) {
+  let attempts = 0;
+
+  while (Date.now() - start < OVERALL_MS - 1500) {
+    attempts++;
+    const remaining = OVERALL_MS - (Date.now() - start);
     const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    const timer = setTimeout(() => ctrl.abort(), Math.min(ATTEMPT_MS, remaining));
+    let transient = false;
     try {
       const r = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${key}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/${READ_MODEL}:generateContent?key=${key}`,
         { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, signal: ctrl.signal }
       );
       if (r.ok) {
         const j = await r.json();
         const text = j?.candidates?.[0]?.content?.parts?.[0]?.text;
         if (text) return text;
-        lastErr = `${model} empty response`;
+        lastErr = `${READ_MODEL} empty response`;
+        transient = true; // worth one more try
+      } else if (r.status === 503 || r.status === 429 || r.status === 500) {
+        lastErr = `${READ_MODEL} HTTP ${r.status} — Google is overloaded, please try again shortly`;
+        transient = true;
       } else {
-        lastErr = `${model} HTTP ${r.status}`;
+        lastErr = `${READ_MODEL} HTTP ${r.status}`; // non-transient — stop
+        break;
       }
     } catch (e: unknown) {
-      lastErr = `${model} ${e instanceof Error && e.name === 'AbortError' ? 'timed out' : (e instanceof Error ? e.message : String(e))}`;
+      lastErr = `${READ_MODEL} ${e instanceof Error && e.name === 'AbortError' ? 'timed out' : (e instanceof Error ? e.message : String(e))}`;
+      transient = true; // timeout — Google was slow, retry if time allows
     } finally {
       clearTimeout(timer);
     }
+    if (!transient) break;
+    // brief backoff before retrying, only if meaningful time remains
+    if (Date.now() - start < OVERALL_MS - 3000) {
+      await new Promise((res) => setTimeout(res, 1200));
+    }
   }
-  throw new Error('AI read failed: ' + lastErr);
+  throw new Error('AI read failed: ' + lastErr + ` (after ${attempts} attempt${attempts === 1 ? '' : 's'})`);
 }
 
 export async function POST(req: Request) {

--- a/src/app/niagawan/purchase/page.tsx
+++ b/src/app/niagawan/purchase/page.tsx
@@ -37,7 +37,19 @@ export default function PurchaseInvoicePage() {
   const [file, setFile] = useState<File | null>(null);
   const [busy, setBusy] = useState(false);
   const [readingId, setReadingId] = useState<string | null>(null);
+  const [readSecs, setReadSecs] = useState(0);
   const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  // Tick a live elapsed-seconds counter while a read is in progress, so the user can see the
+  // system is actively working (an AI read can take 15–50s) and isn't frozen.
+  useEffect(() => {
+    if (!readingId) { setReadSecs(0); return; }
+    setReadSecs(0);
+    const t = setInterval(() => setReadSecs((s) => s + 1), 1000);
+    return () => clearInterval(t);
+  }, [readingId]);
+
+  const readingRow = rows.find((r) => r.id === readingId) ?? null;
 
   useEffect(() => {
     (async () => {
@@ -132,6 +144,24 @@ export default function PurchaseInvoicePage() {
         </div>
         {msg && <div className={`mt-2 rounded-md border p-2 text-sm ${msg.kind === 'ok' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-rose-200 bg-rose-50 text-rose-800'}`}>{msg.text}</div>}
       </div>
+
+      {/* Live processing banner — shows the AI read is actively working (not stuck) */}
+      {readingId && (
+        <div className="mb-4 flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+          <svg className="h-5 w-5 shrink-0 animate-spin text-amber-600" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.4 0 0 5.4 0 12h4z" />
+          </svg>
+          <div className="min-w-0 text-sm">
+            <div className="font-semibold text-amber-900">
+              Reading {readingRow?.ref_no ? <span className="font-mono">{readingRow.ref_no}</span> : 'invoice'} with AI… <span className="tabular-nums">({readSecs}s)</span>
+            </div>
+            <div className="text-xs text-amber-700">
+              This usually takes 15–50 seconds (up to ~60s for big invoices). Please keep this page open — don&apos;t press Read again.
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* List */}
       <div className="mb-2 flex items-center justify-between">


### PR DESCRIPTION
Fixes Purchase Invoice reads. 1) Use only gemini-3.5-flash with thinking OFF (thinkingBudget:0) so it finishes in Vercel 60s; removed 3-model fallback chain that misleadingly reported 'gemini-2.5-flash timed out'; now retries 3.5 on transient 503/429/500/timeout within 52s and reports 'Google is overloaded'. 2) Added a processing banner with live elapsed-seconds counter on the Purchase page while reading.