### PR TITLE
Widen AI-read per-attempt timeout 26s -> 46s

### DIFF
--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -47,7 +47,11 @@ async function geminiExtract(base64: string, key: string, prompt: string): Promi
     generationConfig: { responseMimeType: 'application/json', thinkingConfig: { thinkingBudget: 0 } },
   });
   const OVERALL_MS = 52000; // stay safely under Vercel's 60s function cap
-  const ATTEMPT_MS = 26000; // per-attempt hard timeout
+  // Per-attempt timeout is generous: when 3.5-flash is slow-but-working (overloaded but not
+  // refusing), a big invoice can need 30-45s to finish. A short cap would chop a read that
+  // would have succeeded. Fast failures (503) still return in ~1s, so retries still happen for
+  // those; this long cap only matters when the model actually accepts and is grinding.
+  const ATTEMPT_MS = 46000;
   const start = Date.now();
   let lastErr = '';
   let attempts = 0;


### PR DESCRIPTION
Widen the AI-read per-attempt timeout from 26s to 46s. When gemini-3.5-flash is overloaded-but-working (accepting requests, just slow), a 35-item invoice can need 30-45s; the old 26s cap chopped reads that would have succeeded ('timed out after N attempts'). 503 refusals still fail in ~1s so retries still cover those. Stays within the 52s overall deadline and 60s Vercel cap. Follow-up to #57.