### PR TITLE
Add gemini-2.5-flash as overload-only backup for invoice reads

### DIFF
--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -30,67 +30,71 @@ function buildPrompt(categoryNames: string[]): string {
   );
 }
 
-// We use ONE model — gemini-3.5-flash — because it reads part codes accurately (the old
-// gemini-2.0-flash misread e.g. HUB227->HUB2327). "thinking" is turned OFF (thinkingBudget:0):
-// for a plain read-and-extract job it adds latency without improving accuracy, so disabling it
-// makes the model fast enough to finish inside Vercel's 60s cap.
+// PRIMARY model is gemini-3.5-flash — it reads part codes accurately (the old gemini-2.0-flash
+// misread e.g. HUB227->HUB2327, and is now retired). "thinking" is OFF (thinkingBudget:0): for a
+// plain read-and-extract job it adds latency without improving accuracy.
 //
-// The model itself can be transiently overloaded on Google's side (HTTP 503 / 429 / 500), which
-// shows up as the request hanging then failing. So instead of falling back to a different model,
-// we RETRY gemini-3.5-flash a few times within an overall deadline. Non-transient errors
-// (400/403/404) stop immediately — retrying those is pointless.
-const READ_MODEL = 'gemini-3.5-flash';
+// The newest models get transiently overloaded on Google's side (HTTP 503/429/500 — verified:
+// 3.5-flash can return 100% 503 for stretches in mid-2026 while OTHER models on the SAME key work
+// fine). So we (a) RETRY 3.5-flash within its own time window, then (b) fall back to gemini-2.5-flash
+// ONLY if 3.5 is still down. 2.5-flash is a strong, accurate model (NOT the 2.0-flash that misread)
+// and stays healthy when 3.5 is swamped. The review screen flags which model was used so a backup
+// read gets extra human scrutiny before it reaches Niagawan.
+type ReadTier = { name: string; untilMs: number };
+const READ_TIERS: ReadTier[] = [
+  { name: 'gemini-3.5-flash', untilMs: 32000 }, // primary gets the first ~32s
+  { name: 'gemini-2.5-flash', untilMs: 52000 }, // backup uses the remainder (it answers in ~2s)
+];
+const OVERALL_MS = 52000; // stay safely under Vercel's 60s function cap
+const ATTEMPT_MS = 28000; // per-attempt hard timeout (a slow-but-working read can take ~30s)
 
-async function geminiExtract(base64: string, key: string, prompt: string): Promise<string> {
+async function geminiExtract(base64: string, key: string, prompt: string): Promise<{ text: string; model: string }> {
   const body = JSON.stringify({
     contents: [{ parts: [{ inline_data: { mime_type: 'application/pdf', data: base64 } }, { text: prompt }] }],
     generationConfig: { responseMimeType: 'application/json', thinkingConfig: { thinkingBudget: 0 } },
   });
-  const OVERALL_MS = 52000; // stay safely under Vercel's 60s function cap
-  // Per-attempt timeout is generous: when 3.5-flash is slow-but-working (overloaded but not
-  // refusing), a big invoice can need 30-45s to finish. A short cap would chop a read that
-  // would have succeeded. Fast failures (503) still return in ~1s, so retries still happen for
-  // those; this long cap only matters when the model actually accepts and is grinding.
-  const ATTEMPT_MS = 46000;
   const start = Date.now();
   let lastErr = '';
   let attempts = 0;
 
-  while (Date.now() - start < OVERALL_MS - 1500) {
-    attempts++;
-    const remaining = OVERALL_MS - (Date.now() - start);
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), Math.min(ATTEMPT_MS, remaining));
-    let transient = false;
-    try {
-      const r = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/${READ_MODEL}:generateContent?key=${key}`,
-        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, signal: ctrl.signal }
-      );
-      if (r.ok) {
-        const j = await r.json();
-        const text = j?.candidates?.[0]?.content?.parts?.[0]?.text;
-        if (text) return text;
-        lastErr = `${READ_MODEL} empty response`;
-        transient = true; // worth one more try
-      } else if (r.status === 503 || r.status === 429 || r.status === 500) {
-        lastErr = `${READ_MODEL} HTTP ${r.status} — Google is overloaded, please try again shortly`;
+  for (const tier of READ_TIERS) {
+    const tierDeadline = Math.min(tier.untilMs, OVERALL_MS);
+    while (Date.now() - start < tierDeadline - 1500) {
+      attempts++;
+      const remaining = tierDeadline - (Date.now() - start);
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), Math.min(ATTEMPT_MS, remaining));
+      let transient = false;
+      try {
+        const r = await fetch(
+          `https://generativelanguage.googleapis.com/v1beta/models/${tier.name}:generateContent?key=${key}`,
+          { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, signal: ctrl.signal }
+        );
+        if (r.ok) {
+          const j = await r.json();
+          const text = j?.candidates?.[0]?.content?.parts?.[0]?.text;
+          if (text) return { text, model: tier.name };
+          lastErr = `${tier.name} empty response`;
+          transient = true;
+        } else if (r.status === 503 || r.status === 429 || r.status === 500) {
+          lastErr = `${tier.name} HTTP ${r.status} — overloaded`;
+          transient = true;
+        } else {
+          lastErr = `${tier.name} HTTP ${r.status}`; // non-transient — give up on this tier, try next
+          break;
+        }
+      } catch (e: unknown) {
+        lastErr = `${tier.name} ${e instanceof Error && e.name === 'AbortError' ? 'timed out' : (e instanceof Error ? e.message : String(e))}`;
         transient = true;
-      } else {
-        lastErr = `${READ_MODEL} HTTP ${r.status}`; // non-transient — stop
-        break;
+      } finally {
+        clearTimeout(timer);
       }
-    } catch (e: unknown) {
-      lastErr = `${READ_MODEL} ${e instanceof Error && e.name === 'AbortError' ? 'timed out' : (e instanceof Error ? e.message : String(e))}`;
-      transient = true; // timeout — Google was slow, retry if time allows
-    } finally {
-      clearTimeout(timer);
+      if (!transient) break;
+      if (Date.now() - start < tierDeadline - 3000) {
+        await new Promise((res) => setTimeout(res, 1000));
+      }
     }
-    if (!transient) break;
-    // brief backoff before retrying, only if meaningful time remains
-    if (Date.now() - start < OVERALL_MS - 3000) {
-      await new Promise((res) => setTimeout(res, 1200));
-    }
+    // tier exhausted (still failing) — fall through to the next (backup) model
   }
   throw new Error('AI read failed: ' + lastErr + ` (after ${attempts} attempt${attempts === 1 ? '' : 's'})`);
 }
@@ -126,7 +130,7 @@ export async function POST(req: Request) {
     const categoryNames = (cats ?? []).map((c: { name: string }) => c.name).filter(Boolean);
     const validCats = new Set(categoryNames.map((n) => n.toUpperCase()));
 
-    const text = await geminiExtract(base64, secret.value, buildPrompt(categoryNames));
+    const { text, model: readModel } = await geminiExtract(base64, secret.value, buildPrompt(categoryNames));
     let parsed: { supplier_name?: string; ref_no?: string; invoice_date?: string; total?: number; items?: unknown[] };
     try { parsed = JSON.parse(text); } catch { throw new Error('AI returned invalid data'); }
     const items = Array.isArray(parsed.items) ? parsed.items : [];
@@ -138,6 +142,7 @@ export async function POST(req: Request) {
       total: Number.isFinite(Number(parsed.total)) ? Number(parsed.total) : null,
       status: 'extracted',
       note: null,
+      read_model: readModel, // which AI actually read it (primary 3.5 vs backup 2.5) — shown on review
       resolve_status: 'queued', // NAS will look up each item's existence + category in Niagawan
       updated_at: new Date().toISOString(),
     }).eq('id', id);
@@ -165,7 +170,7 @@ export async function POST(req: Request) {
       await admin.from('pinv_item').insert(rows);
     }
 
-    return NextResponse.json({ ok: true, items: items.length });
+    return NextResponse.json({ ok: true, items: items.length, model: readModel });
   } catch (e: unknown) {
     const m = e instanceof Error ? e.message : String(e);
     if (id) { try { await admin.from('pinv').update({ status: 'error', note: m.slice(0, 300), updated_at: new Date().toISOString() }).eq('id', id); } catch { /* ignore */ } }

--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -17,6 +17,7 @@ type Pinv = {
   check_status: string | null;
   checked_at: string | null;
   resolve_status: string | null;
+  read_model: string | null;
 };
 
 type Item = {
@@ -216,6 +217,13 @@ export default function ReviewInvoicePage() {
         <div className="mb-3 rounded-md border border-indigo-200 bg-indigo-50 p-2 text-sm text-indigo-800">
           This invoice is {head.status}. It can no longer be edited.
         </div>
+      )}
+
+      {/* Which AI read this — flag clearly when the backup model was used so codes get extra scrutiny */}
+      {head.read_model && (
+        head.read_model.includes('3.5')
+          ? <div className="mb-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-500">Read by primary AI (<span className="font-mono">{head.read_model}</span>).</div>
+          : <div className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">⚠️ Read by <b>backup AI</b> (<span className="font-mono">{head.read_model}</span>) because the primary was overloaded. Please <b>double-check the part codes</b> against the PDF before approving.</div>
       )}
 
       {/* Header */}

--- a/src/app/niagawan/purchase/page.tsx
+++ b/src/app/niagawan/purchase/page.tsx
@@ -104,7 +104,8 @@ export default function PurchaseInvoicePage() {
       });
       const j = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(j?.error || `Read failed (${res.status})`);
-      setMsg({ kind: 'ok', text: `Read ✓ — found ${j.items ?? 0} line item${j.items === 1 ? '' : 's'}.` });
+      const backup = typeof j?.model === 'string' && !j.model.includes('3.5');
+      setMsg({ kind: 'ok', text: `Read ✓ — found ${j.items ?? 0} line item${j.items === 1 ? '' : 's'}.${backup ? ` (backup AI ${j.model} — double-check the codes on Review)` : ''}` });
       await load();
     } catch (e: unknown) {
       setMsg({ kind: 'err', text: e instanceof Error ? e.message : String(e) });


### PR DESCRIPTION
Adds gemini-2.5-flash as an overload-only backup for invoice reads. Proven side-by-side (same key+code): 3.5-flash can be 100% 503 while 2.5-flash is 5/5 OK. Read now tries 3.5 first (~32s of retries), falls back to 2.5 only if 3.5 is still down. Records pinv.read_model and shows an amber 'backup AI - double-check codes' warning on the Review screen + a note in the success toast. 3.5 stays primary; review step guards accuracy. Follow-up to #57/#58.