### PR TITLE
Verify invoice codes against the PDF text layer (stop OCR misreads)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,12 @@
         "clsx": "^2.1.1",
         "dayjs": "^1.11.10",
         "leaflet": "^1.9.4",
-        "next": "15.5.4",
+        "next": "15.5.7",
         "pdfkit": "^0.17.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-leaflet": "^5.0.0"
+        "react-leaflet": "^5.0.0",
+        "unpdf": "^1.6.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -28,7 +29,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "15.5.4",
+        "eslint-config-next": "15.5.7",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -777,15 +778,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.4.tgz",
-      "integrity": "sha512-27SQhYp5QryzIT5uO8hq99C69eLQ7qkzkDPsk3N+GuS2XgOgoYEeOav7Pf8Tn4drECOVDsDg8oj+/DVy8qQL2A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
+      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.4.tgz",
-      "integrity": "sha512-SR1vhXNNg16T4zffhJ4TS7Xn7eq4NfKfcOsRwea7RIAHrjRpI9ALYbamqIJqkAhowLlERffiwk0FMvTLNdnVtw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.7.tgz",
+      "integrity": "sha512-DtRU2N7BkGr8r+pExfuWHwMEPX5SD57FeA6pxdgCHODo+b/UgIgjE+rgWKtJAbEbGhVZ2jtHn4g3wNhWFoNBQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -793,9 +794,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.4.tgz",
-      "integrity": "sha512-nopqz+Ov6uvorej8ndRX6HlxCYWCO3AHLfKK2TYvxoSB2scETOcfm/HSS3piPqc3A+MUgyHoqE6je4wnkjfrOA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
+      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
       "cpu": [
         "arm64"
       ],
@@ -809,9 +810,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.4.tgz",
-      "integrity": "sha512-QOTCFq8b09ghfjRJKfb68kU9k2K+2wsC4A67psOiMn849K9ZXgCSRQr0oVHfmKnoqCbEmQWG1f2h1T2vtJJ9mA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
+      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
       "cpu": [
         "x64"
       ],
@@ -825,9 +826,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.4.tgz",
-      "integrity": "sha512-eRD5zkts6jS3VfE/J0Kt1VxdFqTnMc3QgO5lFE5GKN3KDI/uUpSyK3CjQHmfEkYR4wCOl0R0XrsjpxfWEA++XA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
+      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
       "cpu": [
         "arm64"
       ],
@@ -841,9 +842,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.4.tgz",
-      "integrity": "sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
+      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
       "cpu": [
         "arm64"
       ],
@@ -857,9 +858,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.4.tgz",
-      "integrity": "sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
+      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
       "cpu": [
         "x64"
       ],
@@ -873,9 +874,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.4.tgz",
-      "integrity": "sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
+      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
       "cpu": [
         "x64"
       ],
@@ -889,9 +890,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.4.tgz",
-      "integrity": "sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
+      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
       "cpu": [
         "arm64"
       ],
@@ -905,9 +906,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.4.tgz",
-      "integrity": "sha512-1ur2tSHZj8Px/KMAthmuI9FMp/YFusMMGoRNJaRZMOlSkgvLjzosSdQI0cJAKogdHl3qXUQKL9MGaYvKwA7DXg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
+      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
       "cpu": [
         "x64"
       ],
@@ -3000,13 +3001,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.4.tgz",
-      "integrity": "sha512-BzgVVuT3kfJes8i2GHenC1SRJ+W3BTML11lAOYFOOPzrk2xp66jBOAGEFRw+3LkYCln5UzvFsLhojrshb5Zfaw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.7.tgz",
+      "integrity": "sha512-nU/TRGHHeG81NeLW5DeQT5t6BDUqbpsNQTvef1ld/tqHT+/zTx60/TIhKnmPISTTe++DVo+DLxDmk4rnwHaZVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.4",
+        "@next/eslint-plugin-next": "15.5.7",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -4846,12 +4847,13 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.4.tgz",
-      "integrity": "sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
+      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.4",
+        "@next/env": "15.5.7",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4864,14 +4866,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.4",
-        "@next/swc-darwin-x64": "15.5.4",
-        "@next/swc-linux-arm64-gnu": "15.5.4",
-        "@next/swc-linux-arm64-musl": "15.5.4",
-        "@next/swc-linux-x64-gnu": "15.5.4",
-        "@next/swc-linux-x64-musl": "15.5.4",
-        "@next/swc-win32-arm64-msvc": "15.5.4",
-        "@next/swc-win32-x64-msvc": "15.5.4",
+        "@next/swc-darwin-arm64": "15.5.7",
+        "@next/swc-darwin-x64": "15.5.7",
+        "@next/swc-linux-arm64-gnu": "15.5.7",
+        "@next/swc-linux-arm64-musl": "15.5.7",
+        "@next/swc-linux-x64-gnu": "15.5.7",
+        "@next/swc-linux-x64-musl": "15.5.7",
+        "@next/swc-win32-arm64-msvc": "15.5.7",
+        "@next/swc-win32-x64-msvc": "15.5.7",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -6224,6 +6226,20 @@
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "pdfkit": "^0.17.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-leaflet": "^5.0.0"
+    "react-leaflet": "^5.0.0",
+    "unpdf": "^1.6.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -1,9 +1,25 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { createClientServer } from '@/lib/supabaseServer';
+import { extractText, getDocumentProxy } from 'unpdf';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
+
+// Normalise a code/text for matching: uppercase, strip everything except letters+digits.
+// Used to verify each AI-returned code literally appears in the invoice's own text layer.
+const normForMatch = (s: string) => String(s ?? '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+
+// Pull the real text layer out of a (digital) PDF. Returns '' for image-only/scanned PDFs.
+async function extractPdfText(buf: ArrayBuffer): Promise<string> {
+  try {
+    const pdf = await getDocumentProxy(new Uint8Array(buf));
+    const { text } = await extractText(pdf, { mergePages: true });
+    return Array.isArray(text) ? text.join('\n') : String(text ?? '');
+  } catch {
+    return '';
+  }
+}
 
 const admin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -11,10 +27,19 @@ const admin = createClient(
   { auth: { persistSession: false } }
 );
 
-function buildPrompt(categoryNames: string[]): string {
+function buildPrompt(categoryNames: string[], invoiceText: string): string {
   const catLine = categoryNames.length
     ? ' For each item also pick the single best "category" from EXACTLY this list (copy the name verbatim, do not invent new ones): ' +
       categoryNames.join(' | ') + '. If unsure, use "SPARE PARTS ITEM".'
+    : '';
+  // The PDF's own text layer is provided as the AUTHORITATIVE source for codes. This is exact
+  // text from the file (not OCR), so the model must copy codes from it verbatim rather than
+  // "reading" them off the image — that is what prevents misreads like VF21 -> VF17.
+  const textBlock = invoiceText.trim()
+    ? '\n\nThe EXACT text of this invoice (extracted directly from the PDF, character-for-character) is between the markers below. ' +
+      'Treat this text as the AUTHORITATIVE source for every product code: copy codes EXACTLY as they appear here, character for character. ' +
+      'Use the attached PDF only for layout/structure if helpful. Do NOT invent or alter any code.\n' +
+      '<<<INVOICE_TEXT>>>\n' + invoiceText.slice(0, 24000) + '\n<<<END_INVOICE_TEXT>>>'
     : '';
   return (
     'Read this supplier auto-parts purchase invoice. Return ONLY JSON with this shape: ' +
@@ -26,7 +51,8 @@ function buildPrompt(categoryNames: string[]): string {
     'If the invoice has a clean Item Code column, that single code is the only entry in "codes". If several codes are embedded in the description, include them ALL, in the order they appear. ' +
     '"description" = a clean human description of the item WITHOUT the codes: item type + vehicle model + year, e.g. "CONDENSER W/DRIER JAZZ FREED CRZ 09". ' +
     'Include every line item. ref_no is the supplier invoice number. If a field is missing use null.' +
-    catLine
+    catLine +
+    textBlock
   );
 }
 
@@ -121,7 +147,17 @@ export async function POST(req: Request) {
 
     const { data: blob, error: dErr } = await admin.storage.from('pinv').download(row.file_path);
     if (dErr || !blob) throw new Error('Could not read the PDF: ' + (dErr?.message ?? ''));
-    const base64 = Buffer.from(await blob.arrayBuffer()).toString('base64');
+    const ab = await blob.arrayBuffer();
+    const base64 = Buffer.from(ab).toString('base64');
+
+    // Extract the PDF's real text layer. For digital invoices this is exact (no OCR), and we
+    // feed it to the AI as the authoritative source for codes. If there's essentially no text,
+    // it's a scanned/photo PDF — stop rather than risk a silent misread.
+    const invoiceText = await extractPdfText(ab);
+    if (normForMatch(invoiceText).length < 40) {
+      throw new Error('This looks like a scanned/photo PDF (no readable text layer). Please upload a digital PDF invoice.');
+    }
+    const textNorm = normForMatch(invoiceText);
 
     const { data: secret } = await admin.from('app_secrets').select('value').eq('name', 'gemini_key').single();
     if (!secret?.value) throw new Error('AI key not configured');
@@ -130,7 +166,7 @@ export async function POST(req: Request) {
     const categoryNames = (cats ?? []).map((c: { name: string }) => c.name).filter(Boolean);
     const validCats = new Set(categoryNames.map((n) => n.toUpperCase()));
 
-    const { text, model: readModel } = await geminiExtract(base64, secret.value, buildPrompt(categoryNames));
+    const { text, model: readModel } = await geminiExtract(base64, secret.value, buildPrompt(categoryNames, invoiceText));
     let parsed: { supplier_name?: string; ref_no?: string; invoice_date?: string; total?: number; items?: unknown[] };
     try { parsed = JSON.parse(text); } catch { throw new Error('AI returned invalid data'); }
     const items = Array.isArray(parsed.items) ? parsed.items : [];
@@ -155,6 +191,9 @@ export async function POST(req: Request) {
         // Normalise the codes list (fallback to a single item_code if the model returned that).
         let codes = Array.isArray(it.codes) ? it.codes.map((c) => String(c ?? '').trim()).filter(Boolean) : [];
         if (codes.length === 0 && it.item_code) { const c = String(it.item_code).trim(); if (c) codes = [c]; }
+        // Verify every code actually appears in the invoice's own text layer. If a code is NOT
+        // found, the AI likely misread it — flag it so the Review screen can highlight it red.
+        const code_verified = codes.length > 0 && codes.every((c) => textNorm.includes(normForMatch(c)));
         return {
           pinv_id: id,
           line_no: i + 1,
@@ -165,12 +204,15 @@ export async function POST(req: Request) {
           unit_price: Number(it.unit_price) || 0,
           amount: Number(it.amount) || 0,
           category: cat && validCats.has(cat.toUpperCase()) ? cat : 'SPARE PARTS ITEM',
+          code_verified,
         };
       });
       await admin.from('pinv_item').insert(rows);
+      const flagged = rows.filter((r) => !r.code_verified).length;
+      return NextResponse.json({ ok: true, items: items.length, model: readModel, flagged });
     }
 
-    return NextResponse.json({ ok: true, items: items.length, model: readModel });
+    return NextResponse.json({ ok: true, items: items.length, model: readModel, flagged: 0 });
   } catch (e: unknown) {
     const m = e instanceof Error ? e.message : String(e);
     if (id) { try { await admin.from('pinv').update({ status: 'error', note: m.slice(0, 300), updated_at: new Date().toISOString() }).eq('id', id); } catch { /* ignore */ } }

--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -34,6 +34,7 @@ type Item = {
   sold_on: string | null;
   in_niagawan: boolean | null;
   niagawan_category: string | null;
+  code_verified: boolean | null;
 };
 
 const rm = (n: number) => `RM ${Number(n || 0).toLocaleString('en-MY', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -84,6 +85,7 @@ export default function ReviewInvoicePage() {
         sold_on: (r.sold_on as string) ?? null,
         in_niagawan: (r.in_niagawan as boolean | null) ?? null,
         niagawan_category: (r.niagawan_category as string) ?? null,
+        code_verified: (r.code_verified as boolean | null) ?? null,
       }))
     );
     setLoading(false);
@@ -97,7 +99,7 @@ export default function ReviewInvoicePage() {
   const setItem = (idx: number, patch: Partial<Item>) => {
     setItems((prev) => prev.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
   };
-  const addRow = () => setItems((prev) => [...prev, { line_no: prev.length + 1, item_code: '', codes: [], description: '', qty: 1, unit_price: 0, amount: 0, category: 'SPARE PARTS ITEM', will_create: true, sold_status: null, sold_on: null, in_niagawan: null, niagawan_category: null }]);
+  const addRow = () => setItems((prev) => [...prev, { line_no: prev.length + 1, item_code: '', codes: [], description: '', qty: 1, unit_price: 0, amount: 0, category: 'SPARE PARTS ITEM', will_create: true, sold_status: null, sold_on: null, in_niagawan: null, niagawan_category: null, code_verified: null }]);
   const removeRow = (idx: number) => setItems((prev) => prev.filter((_, i) => i !== idx).map((it, i) => ({ ...it, line_no: i + 1 })));
 
   const save = useCallback(async (approve: boolean) => {
@@ -134,6 +136,7 @@ export default function ReviewInvoicePage() {
           unit_price: it.unit_price,
           amount: it.amount,
           category: it.category || 'SPARE PARTS ITEM',
+          code_verified: it.code_verified, // keep the read-time flag (cleared to null when the code is edited)
           // matched / will_create are decided authoritatively by the NAS at create time
         }));
         const { error: iErr } = await supabase.from('pinv_item').insert(rows);
@@ -226,6 +229,17 @@ export default function ReviewInvoicePage() {
           : <div className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">⚠️ Read by <b>backup AI</b> (<span className="font-mono">{head.read_model}</span>) because the primary was overloaded. Please <b>double-check the part codes</b> against the PDF before approving.</div>
       )}
 
+      {/* Code-verification summary: codes that weren't found verbatim in the PDF's own text */}
+      {(() => {
+        const bad = items.filter((it) => it.code_verified === false);
+        if (bad.length === 0) return null;
+        return (
+          <div className="mb-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-rose-800">
+            ⚠ <b>{bad.length} code{bad.length === 1 ? '' : 's'} not found in the PDF text</b> (lines {bad.map((b) => b.line_no).join(', ')}) — the AI may have misread {bad.length === 1 ? 'it' : 'them'}. They're highlighted red below; please check against the PDF before approving.
+          </div>
+        );
+      })()}
+
       {/* Header */}
       <div className="mb-4 rounded-lg border border-gray-200 bg-white p-4">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -294,8 +308,13 @@ export default function ReviewInvoicePage() {
                 <tr key={idx} className="border-t border-gray-100 align-top">
                   <td className="px-2 py-1.5 text-gray-400">{idx + 1}</td>
                   <td className="px-2 py-1.5">
-                    <input disabled={locked} value={it.item_code} onChange={(e) => setItem(idx, { item_code: e.target.value })}
-                      className="w-36 rounded border border-gray-200 px-1.5 py-1 font-mono text-xs disabled:bg-transparent disabled:border-transparent" />
+                    <input disabled={locked} value={it.item_code} onChange={(e) => setItem(idx, { item_code: e.target.value, code_verified: null })}
+                      className={`w-36 rounded border px-1.5 py-1 font-mono text-xs disabled:bg-transparent ${it.code_verified === false ? 'border-rose-400 bg-rose-50' : 'border-gray-200 disabled:border-transparent'}`} />
+                    {it.code_verified === false && (
+                      <div className="mt-0.5 max-w-[12rem] text-[10px] font-medium leading-tight text-rose-600" title="This code was NOT found in the invoice's text — the AI may have misread it. Check it against the PDF.">
+                        ⚠ not found in PDF text — check it
+                      </div>
+                    )}
                     {it.codes.length > 1 && (
                       <div className="mt-1 max-w-[12rem] font-mono text-[10px] leading-tight text-gray-400" title={'All codes recognised on this line:\n' + it.codes.join('  ')}>
                         +{it.codes.length - 1} more: {it.codes.slice(1).join(' ')}

--- a/src/app/niagawan/purchase/page.tsx
+++ b/src/app/niagawan/purchase/page.tsx
@@ -105,7 +105,8 @@ export default function PurchaseInvoicePage() {
       const j = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(j?.error || `Read failed (${res.status})`);
       const backup = typeof j?.model === 'string' && !j.model.includes('3.5');
-      setMsg({ kind: 'ok', text: `Read ✓ — found ${j.items ?? 0} line item${j.items === 1 ? '' : 's'}.${backup ? ` (backup AI ${j.model} — double-check the codes on Review)` : ''}` });
+      const flagged = Number(j?.flagged) || 0;
+      setMsg({ kind: flagged ? 'err' : 'ok', text: `Read ✓ — found ${j.items ?? 0} line item${j.items === 1 ? '' : 's'}.${backup ? ` (backup AI ${j.model})` : ''}${flagged ? ` ⚠ ${flagged} code${flagged === 1 ? '' : 's'} not found in the PDF text — check on Review.` : ''}` });
       await load();
     } catch (e: unknown) {
       setMsg({ kind: 'err', text: e instanceof Error ? e.message : String(e) });


### PR DESCRIPTION
Root-cause fix for OCR code misreads. Your supplier invoices are digital PDFs with an exact text layer, so instead of making the AI read codes off a rendered image (where VF21 became VF17), we extract the PDF text (unpdf) and feed it to the AI as the authoritative source for codes, then cross-check every returned code against that text. Codes not found verbatim are flagged red on Review (pinv_item.code_verified) with a summary banner + toast note. A PDF with no text layer (a scan) is rejected with a clear message. Verified end-to-end: unpdf extracts INV2606_0064.pdf cleanly (4550 chars), all real codes found, fake code not found. Follow-up to #59.