### PR TITLE
Warn + block duplicate purchase invoices (same supplier ref)

### DIFF
--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -18,6 +18,7 @@ type Pinv = {
   checked_at: string | null;
   resolve_status: string | null;
   read_model: string | null;
+  dup_pi_no: string | null;
 };
 
 type Item = {
@@ -225,6 +226,13 @@ export default function ReviewInvoicePage() {
       {locked && (
         <div className="mb-3 rounded-md border border-indigo-200 bg-indigo-50 p-2 text-sm text-indigo-800">
           This invoice is {head.status}. It can no longer be edited.
+        </div>
+      )}
+
+      {/* Duplicate guard: this supplier invoice ref already exists in Niagawan */}
+      {head.dup_pi_no && head.status !== 'created' && (
+        <div className="mb-3 rounded-md border-2 border-rose-400 bg-rose-50 p-3 text-sm text-rose-800">
+          ⚠️ <b>Possible duplicate.</b> This supplier invoice{head.ref_no ? <> (<span className="font-mono">{head.ref_no}</span>)</> : ''} is <b>already in Niagawan</b> as <b className="font-mono">{head.dup_pi_no}</b>. Approving would create a second copy — only approve if this is genuinely a new, separate invoice. (The system will also refuse to create a duplicate.)
         </div>
       )}
 


### PR DESCRIPTION
Prevents accidentally entering the same supplier invoice twice. NAS findPurchaseByRef() searches Niagawan (listPurchase searchkeyword, exact REF# cell match) for the supplier ref; the resolve step (runs on read) stores any match in pinv.dup_pi_no, and the review screen shows a red 'Possible duplicate - already in Niagawan as P26xxxx' banner before approval. Safety net: piCreate refuses to create if the ref already exists. Edge fn v8: getResolveJobs returns ref_no, markResolve stores dup_pi_no. Verified live: I2605525 -> P2600381, INV2606/0064 -> P2600461.