### PR TITLE
KIV manual move: source date -> target date

### DIFF
--- a/src/app/niagawan/kiv/sale-invoice/page.tsx
+++ b/src/app/niagawan/kiv/sale-invoice/page.tsx
@@ -40,8 +40,14 @@ export default function KivSaleInvoicePage() {
   const [runMsg, setRunMsg] = useState('');
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const todayISO = new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10); // KL date
-  const [fromDate, setFromDate] = useState(todayISO);
-  const [toDate, setToDate] = useState(todayISO);
+  // Default target = next working day after today (Sunday closed: Saturday -> Monday).
+  const nextWorking = (() => {
+    const d = new Date(Date.now() + 8 * 3600 * 1000 + 86400 * 1000);
+    if (d.getUTCDay() === 0) d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().slice(0, 10);
+  })();
+  const [fromDate, setFromDate] = useState(todayISO);   // source: the day whose unpaid invoices to move
+  const [toDate, setToDate] = useState(nextWorking);    // target: the date to move them TO
 
   useEffect(() => {
     (async () => {
@@ -75,11 +81,13 @@ export default function KivSaleInvoicePage() {
   const moveNow = useCallback(async () => {
     if (run === 'running') return;
     if (!fromDate || !toDate) { setRun('error'); setRunMsg('Pick both dates.'); return; }
-    if (fromDate > toDate) { setRun('error'); setRunMsg('"From" must be on or before "To".'); return; }
+    if (fromDate === toDate) { setRun('error'); setRunMsg('The two dates must be different.'); return; }
     const fmt = (d: string) => d.split('-').reverse().join('/');
+    const sunday = new Date(toDate + 'T00:00:00Z').getUTCDay() === 0;
     if (!window.confirm(
-      `Move UNPAID sale invoices dated ${fmt(fromDate)} – ${fmt(toDate)} to the next working day?\n\n` +
-      'Each one is first marked delivered (dated the day the car came in), then its invoice date is moved. ' +
+      `Move UNPAID sale invoices dated ${fmt(fromDate)} to ${fmt(toDate)}?\n\n` +
+      (sunday ? '⚠ Note: the target date is a SUNDAY (workshop closed).\n\n' : '') +
+      'Each one is first marked delivered (dated the day the car came in), then its invoice date is changed. ' +
       'This changes real invoices in Niagawan — normally the 19:45 schedule does this automatically for today.'
     )) return;
     setRun('running');
@@ -132,13 +140,14 @@ export default function KivSaleInvoicePage() {
           </div>
           <div className="flex flex-wrap items-end gap-2">
             <label className="text-[11px] text-gray-500">
-              From
+              Invoices dated
               <input type="date" value={fromDate} max={todayISO} onChange={(e) => setFromDate(e.target.value)}
                 className="mt-0.5 block rounded-md border border-gray-300 px-2 py-1 text-xs" />
             </label>
+            <span className="pb-1.5 text-gray-400">→</span>
             <label className="text-[11px] text-gray-500">
-              To
-              <input type="date" value={toDate} max={todayISO} onChange={(e) => setToDate(e.target.value)}
+              Move to
+              <input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)}
                 className="mt-0.5 block rounded-md border border-gray-300 px-2 py-1 text-xs" />
             </label>
             <button


### PR DESCRIPTION
Pickers now mean 'Invoices dated' (source day whose unpaid invoices move) -> 'Move to' (owner-chosen target date, future allowed, Sunday warning). NAS kiv-move CLI: [dry|live] [source] [target]; the 19:45 schedule still defaults today -> next working day.