### PR TITLE
Evening carry-forward: Settings copy + corrected CLAUDE.md gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ A cloud/web Claude session **can** edit this repo and open PRs. It **cannot** re
 
 ## Niagawan gotchas (learned the hard way)
 
-- `updateSale` with a **future** sale date silently fails AND reverts the invoice to its original date — the KIV carry-forward must only move *backward-dated* invoices to **today** (it runs mornings: yesterday → today; Monday picks up Sat+Sun). Target date may never exceed today.
+- `updateSale` DOES accept a future sale date (proven 2026-06-12 on a dummy invoice — an earlier belief that future dates corrupt invoices was a misdiagnosis of manual re-dating). The KIV carry-forward runs **evenings at 20:00**: today's unpaid → next working day (Saturday's → Monday), then re-syncs the affected days. A 7-days-ahead cap guards against typos on manual runs.
 - `deliverDO` with an empty ship date sets it to **today**.
 - The KIV "delivered" date = the date the workshop received the car, not the invoice date.
 - Only **unpaid** invoices are carried forward (partials are tracked separately on the KIV page, scanned nightly per year).

--- a/src/app/niagawan/settings/page.tsx
+++ b/src/app/niagawan/settings/page.tsx
@@ -22,7 +22,7 @@ const META: Record<string, { title: string; desc: string; fields: Array<'period'
   },
   kiv_move: {
     title: 'Move unpaid sale invoices (carry forward)',
-    desc: 'Every morning, any sale invoice from the previous working day that is still fully unpaid is marked delivered (dated the day the car came in) and moved to today (Monday picks up Saturday), so each day’s final sales/COGS shows only completed, paid work. Runs in the morning because Niagawan does not accept future invoice dates. Every move is listed on the KIV Invoices tab and emailed to you.',
+    desc: 'Every evening after closing (8pm), any sale invoice from today that is still fully unpaid is marked delivered (dated the day the car came in) and moved to the next working day (Saturday’s go to Monday) — so the day’s sales/COGS are clean the same night. The affected days are re-synced automatically right after the move. Every move is listed on the KIV Invoices tab and emailed to you.',
     fields: ['time'],
   },
   kiv_partial: {


### PR DESCRIPTION
kiv_move now runs evenings 20:00 moving today's unpaid to the next working day (future dates proven to work on a dummy invoice); nightly sync 20:30; partial scan 20:45. [Generated with Claude Code](https://claude.com/claude-code)