### PR TITLE
add-part polish: English UI, vehicle labels, cost price, status table

### DIFF
--- a/src/app/add-part/page.tsx
+++ b/src/app/add-part/page.tsx
@@ -1,17 +1,23 @@
 // src/app/add-part/page.tsx — "part arrived" v2.
 // Type a few letters of the code or name -> instant list from the synced product catalog ->
 // tap the EXACT product -> it queues in the background and the form resets immediately.
-// A status strip shows each queued item turning ✓ as the NAS lands it on the invoice.
+// A status table shows each queued item turning ✓ as the NAS lands it on the invoice.
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 
 type OpenInv = { inv: string; sale_id: string; customer: string | null };
-type Product = { sku: string; code: string | null; descp: string | null; price: number | string | null };
-type Queued = { id: number; label: string; status: 'pending' | 'done' | 'error'; result?: string };
+type Product = { sku: string; code: string | null; descp: string | null; price: number | string | null; cost: number | string | null };
+type Queued = { id: number; item: string; qty: number; car: string; status: 'pending' | 'done' | 'error'; result?: string };
 
-const rm = (x: unknown) => { const v = Number(x); return Number.isFinite(v) ? `RM ${v.toFixed(2)}` : ''; };
+const rm = (x: unknown) => { const v = Number(x); return Number.isFinite(v) ? `RM ${v.toFixed(2)}` : '—'; };
+// niagawan_sale_inv.customer is "VEHICLE PLATE<invoiceNo>, , <cashier login>" — keep the vehicle+plate part only
+const carLabel = (c: OpenInv) => {
+  const raw = String(c.customer ?? '');
+  const clean = (raw.split(c.inv)[0] || raw).replace(/[,\s]+$/, '').trim();
+  return clean || c.inv;
+};
 
 export default function AddPartPage() {
   const [authed, setAuthed] = useState<boolean | null>(null);
@@ -56,7 +62,7 @@ export default function AddPartPage() {
       const like = `%${term.replace(/[%_]/g, '')}%`;
       const { data } = await supabase
         .from('niagawan_products')
-        .select('sku,code,descp,price')
+        .select('sku,code,descp,price,cost')
         .or(`code.ilike.${like},descp.ilike.${like}`)
         .limit(12);
       setResults((data ?? []) as Product[]);
@@ -81,52 +87,51 @@ export default function AddPartPage() {
   }, [queue]);
 
   const add = useCallback(async () => {
-    if (!picked) { setErrMsg('Sila pilih kereta dulu.'); return; }
-    if (!chosen) { setErrMsg('Sila pilih item dari senarai.'); return; }
+    if (!picked) { setErrMsg('Pick a vehicle first.'); return; }
+    if (!chosen) { setErrMsg('Pick an item from the list.'); return; }
     setErrMsg(null);
     const { data: id, error } = await supabase.rpc('queue_add_item', {
       p_inv: picked.inv, p_sale_id: picked.sale_id, p_plate: picked.customer ?? '',
       p_code: chosen.code ?? '', p_qty: qty, p_sku: chosen.sku, p_descp: chosen.descp ?? '',
     });
     if (error || !id) { setErrMsg(error?.message ?? 'failed'); return; }
-    const label = `${chosen.descp ?? chosen.code} ×${qty} → ${picked.customer ?? picked.inv}`;
-    setQueue((prev) => [{ id: id as number, label, status: 'pending' as const }, ...prev].slice(0, 8));
-    // fire-and-forget: reset the item immediately, keep the same car selected
+    const entry: Queued = {
+      id: id as number, item: chosen.descp || chosen.code || '?', qty,
+      car: carLabel(picked), status: 'pending',
+    };
+    setQueue((prev) => [entry, ...prev].slice(0, 8));
+    // fire-and-forget: reset the item immediately, keep the same vehicle selected
     setQ(''); setResults([]); setChosen(null); setQty(1);
   }, [picked, chosen, qty]);
 
   if (authed === null) return <div className="p-6 text-sm text-gray-500">Checking…</div>;
   if (!authed) return <div className="p-6 text-sm text-gray-600">Please sign in first.</div>;
 
-  const shown = cars.filter((c) => !filter.trim() || String(c.customer ?? c.inv).toUpperCase().includes(filter.trim().toUpperCase()));
+  const shown = cars.filter((c) => !filter.trim() || carLabel(c).toUpperCase().includes(filter.trim().toUpperCase()));
 
   return (
     <div className="mx-auto max-w-md px-5 py-6">
-      <h1 className="text-2xl font-bold text-gray-900">🔩 Part Sampai</h1>
+      <h1 className="text-2xl font-bold text-gray-900">🔩 Part Arrived</h1>
 
-      {/* 1) car */}
+      {/* 1) vehicle */}
       <div className="mt-4">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-gray-700">1. Kereta {picked ? '✓' : `(${cars.length} dalam workshop)`}</span>
+          <span className="text-sm font-medium text-gray-700">1. Vehicle {picked ? '✓' : `(${cars.length} in workshop)`}</span>
           {!picked && cars.length > 6 && (
-            <input value={filter} onChange={(e) => setFilter(e.target.value)} placeholder="cari plat…" className="w-32 rounded-lg border border-gray-300 px-2 py-1 text-sm" />
+            <input value={filter} onChange={(e) => setFilter(e.target.value)} placeholder="search plate…" className="w-32 rounded-lg border border-gray-300 px-2 py-1 text-sm" />
           )}
         </div>
         {picked ? (
           <button onClick={() => setPicked(null)} className="mt-2 flex w-full items-center justify-between rounded-xl border border-blue-600 bg-blue-50 px-3 py-2.5 text-left">
-            <span className="min-w-0">
-              <span className="block truncate text-sm font-semibold text-blue-900">{picked.customer || '(no name)'}</span>
-              <span className="font-mono text-xs text-blue-400">{picked.inv}</span>
-            </span>
-            <span className="shrink-0 text-xs text-blue-500 underline">tukar</span>
+            <span className="truncate text-sm font-semibold text-blue-900">{carLabel(picked)}</span>
+            <span className="shrink-0 rounded-lg border border-blue-300 px-2 py-1 text-xs font-medium text-blue-600">Change vehicle</span>
           </button>
         ) : (
           <div className="mt-2 grid max-h-56 grid-cols-1 gap-1.5 overflow-y-auto">
-            {shown.length === 0 && <div className="text-sm text-gray-400">Tiada invois unpaid aktif.</div>}
+            {shown.length === 0 && <div className="text-sm text-gray-400">No open unpaid invoices.</div>}
             {shown.map((c) => (
               <button key={c.inv} onClick={() => setPicked(c)} className="rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-left text-sm text-gray-800 hover:border-gray-300">
-                <span className="block truncate">{c.customer || '(no name)'}</span>
-                <span className="font-mono text-xs text-gray-400">{c.inv}</span>
+                <span className="block truncate">{carLabel(c)}</span>
               </button>
             ))}
           </div>
@@ -135,34 +140,34 @@ export default function AddPartPage() {
 
       {/* 2) part search */}
       <div className="mt-5">
-        <span className="text-sm font-medium text-gray-700">2. Cari item (kod atau nama)</span>
-        <input value={q} onChange={(e) => search(e.target.value)} placeholder="cth: MRDB atau BRAKE PAD" autoComplete="off"
+        <span className="text-sm font-medium text-gray-700">2. Search item (code or name)</span>
+        <input value={q} onChange={(e) => search(e.target.value)} placeholder="e.g. MRDB or BRAKE PAD" autoComplete="off"
           className="mt-1 w-full rounded-xl border border-gray-300 px-4 py-3.5 text-lg uppercase" />
         {chosen ? (
           <div className="mt-2 flex items-center justify-between rounded-xl border border-emerald-400 bg-emerald-50 px-3 py-2.5">
             <span className="min-w-0">
               <span className="block truncate text-sm font-semibold text-emerald-900">{chosen.descp}</span>
-              <span className="font-mono text-xs text-emerald-600">{chosen.code} {rm(chosen.price)}</span>
+              <span className="font-mono text-xs text-emerald-600">{chosen.code || '—'} · Price {rm(chosen.price)} · Cost {rm(chosen.cost)}</span>
             </span>
-            <button onClick={() => { setChosen(null); setQ(''); }} className="shrink-0 text-xs text-emerald-600 underline">tukar</button>
+            <button onClick={() => { setChosen(null); setQ(''); }} className="shrink-0 text-xs text-emerald-600 underline">change</button>
           </div>
         ) : results.length > 0 ? (
           <div className="mt-2 grid max-h-64 grid-cols-1 gap-1.5 overflow-y-auto">
             {results.map((p) => (
               <button key={p.sku} onClick={() => { setChosen(p); setResults([]); }} className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-left hover:border-gray-300">
                 <span className="block truncate text-sm text-gray-900">{p.descp || '(no name)'}</span>
-                <span className="font-mono text-xs text-gray-400">{p.code || '—'} <span className="text-gray-500">{rm(p.price)}</span></span>
+                <span className="font-mono text-xs text-gray-400">{p.code || '—'} · <span className="text-gray-600">Price {rm(p.price)}</span> · <span className="text-amber-700">Cost {rm(p.cost)}</span></span>
               </button>
             ))}
           </div>
         ) : q.trim().length >= 2 ? (
-          <div className="mt-2 text-sm text-gray-400">Tiada item sepadan… semak ejaan.</div>
+          <div className="mt-2 text-sm text-gray-400">No matching item… check the spelling.</div>
         ) : null}
       </div>
 
       {/* 3) qty + go */}
       <div className="mt-4 flex items-center gap-3">
-        <span className="text-sm font-medium text-gray-700">Kuantiti:</span>
+        <span className="text-sm font-medium text-gray-700">Quantity:</span>
         <button onClick={() => setQty((v) => Math.max(1, v - 1))} className="h-11 w-11 rounded-xl border border-gray-300 text-xl font-bold text-gray-700">−</button>
         <span className="w-10 text-center text-xl font-bold">{qty}</span>
         <button onClick={() => setQty((v) => v + 1)} className="h-11 w-11 rounded-xl border border-gray-300 text-xl font-bold text-gray-700">+</button>
@@ -172,22 +177,37 @@ export default function AddPartPage() {
 
       <button onClick={add} disabled={!picked || !chosen}
         className="mt-4 w-full rounded-xl bg-blue-600 px-6 py-4 text-xl font-bold text-white hover:bg-blue-700 disabled:opacity-40">
-        MASUKKAN KE INVOIS
+        ADD TO INVOICE
       </button>
 
       {/* queue status */}
       {queue.length > 0 && (
-        <div className="mt-5 space-y-1.5">
+        <div className="mt-5">
           <div className="text-xs font-semibold uppercase tracking-wide text-gray-400">Status</div>
-          {queue.map((x) => (
-            <div key={x.id} className={`flex items-start gap-2 rounded-lg border px-3 py-2 text-sm ${x.status === 'done' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : x.status === 'error' ? 'border-rose-200 bg-rose-50 text-rose-700' : 'border-gray-200 bg-gray-50 text-gray-600'}`}>
-              <span className="shrink-0">{x.status === 'done' ? '✅' : x.status === 'error' ? '⚠️' : '⏳'}</span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate">{x.label}</span>
-                {x.result && <span className="block truncate text-xs opacity-75">{x.result}</span>}
-              </span>
-            </div>
-          ))}
+          <div className="mt-1.5 overflow-hidden rounded-xl border border-gray-200">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 text-left text-xs text-gray-500">
+                  <th className="px-3 py-2 font-medium">Item</th>
+                  <th className="px-2 py-2 font-medium">Qty</th>
+                  <th className="px-2 py-2 font-medium">Vehicle</th>
+                  <th className="px-3 py-2 text-right font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {queue.map((x) => (
+                  <tr key={x.id} className={`border-t border-gray-100 ${x.status === 'done' ? 'bg-emerald-50/50' : x.status === 'error' ? 'bg-rose-50/50' : ''}`}>
+                    <td className="max-w-[10rem] truncate px-3 py-2 text-gray-800" title={x.item}>{x.item}</td>
+                    <td className="px-2 py-2 text-gray-600">×{x.qty}</td>
+                    <td className="max-w-[7rem] truncate px-2 py-2 text-gray-600" title={x.car}>{x.car}</td>
+                    <td className="px-3 py-2 text-right" title={x.result ?? ''}>
+                      {x.status === 'done' ? '✅' : x.status === 'error' ? <span className="text-xs text-rose-600">⚠️ failed</span> : '⏳'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -152,7 +152,7 @@ export default function WorkshopBoardPage() {
         <h1 className="text-2xl font-semibold text-gray-900">Workshop</h1>
         <span className="text-sm text-gray-400">{cards.filter((c) => c.status !== 'done').length} car(s) in the shop</span>
         <span className="ml-auto flex gap-2">
-          <a href="/add-part" className="rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700 hover:bg-amber-100">🔩 Part sampai</a>
+          <a href="/add-part" className="rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700 hover:bg-amber-100">🔩 Part arrived</a>
           {canWrite && (
             <>
               <a href="/intake" className="rounded-md border border-blue-300 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 hover:bg-blue-100">📝 Customer check-in</a>


### PR DESCRIPTION
Owner feedback round on /add-part: (1) all labels in English, (2) vehicle buttons show vehicle + plate only (strip invoice no + cashier login from the Niagawan customer cell), (3) Cost shown next to Price in search results and the chosen-item chip (catalog now syncs Cost/Unit), (4) status strip is a table (Item / Qty / Vehicle / Status), (5) explicit Change-vehicle button. Also renames the Workshop board button to Part arrived.