### PR TITLE
workshop: board mirrors all of today's paid cars in Done

### DIFF
--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -152,7 +152,15 @@ export default function WorkshopBoardPage() {
 
   const byCol = useMemo(() => {
     const map: Record<string, Card[]> = { waiting: [], doing: [], waiting_parts: [], done: [] };
-    for (const c of cards) (map[c.status] ?? map.waiting).push(c);
+    const todayStr = new Date().toDateString();
+    for (const c of cards) {
+      // Done shows only TODAY's completed cars (older ones stay in the data but don't clutter the board).
+      if (c.status === 'done') {
+        const when = c.done_at ?? c.created_at;
+        if (when && new Date(when).toDateString() !== todayStr) continue;
+      }
+      (map[c.status] ?? map.waiting).push(c);
+    }
     return map;
   }, [cards]);
 


### PR DESCRIPTION
Done was only showing cars that were active then paid (5), not invoices already paid before the board saw them. Mirror trigger now creates Done cards for already-paid plated invoices; Done column limited to today's completions so it stays clean. Backfilled today.