### PR TITLE
workshop: supervisors/admins only

### DIFF
--- a/src/app/add-part/page.tsx
+++ b/src/app/add-part/page.tsx
@@ -21,6 +21,7 @@ const carLabel = (c: OpenInv) => {
 
 export default function AddPartPage() {
   const [authed, setAuthed] = useState<boolean | null>(null);
+  const [allowed, setAllowed] = useState<boolean | null>(null); // supervisors/admins only
   const [cars, setCars] = useState<OpenInv[]>([]);
   const [picked, setPicked] = useState<OpenInv | null>(null);
   const [filter, setFilter] = useState('');
@@ -36,6 +37,10 @@ export default function AddPartPage() {
     (async () => {
       const { data } = await supabase.auth.getSession();
       setAuthed(!!data.session);
+      if (data.session) {
+        const { data: bw } = await supabase.rpc('is_board_writer');
+        setAllowed(bw === true);
+      } else setAllowed(false);
     })();
   }, []);
 
@@ -45,11 +50,11 @@ export default function AddPartPage() {
   }, []);
 
   useEffect(() => {
-    if (!authed) return;
+    if (!authed || allowed !== true) return;
     loadCars();
     const t = setInterval(loadCars, 30000);
     return () => clearInterval(t);
-  }, [authed, loadCars]);
+  }, [authed, allowed, loadCars]);
 
   // Instant product search against the synced catalog (no Niagawan round-trip).
   const search = useCallback((text: string) => {
@@ -104,8 +109,9 @@ export default function AddPartPage() {
     setQ(''); setResults([]); setChosen(null); setQty(1);
   }, [picked, chosen, qty]);
 
-  if (authed === null) return <div className="p-6 text-sm text-gray-500">Checking…</div>;
+  if (authed === null || (authed && allowed === null)) return <div className="p-6 text-sm text-gray-500">Checking…</div>;
   if (!authed) return <div className="p-6 text-sm text-gray-600">Please sign in first.</div>;
+  if (!allowed) return <div className="p-6 text-sm text-gray-600">This page is for supervisors only.</div>;
 
   const shown = cars.filter((c) => !filter.trim() || carLabel(c).toUpperCase().includes(filter.trim().toUpperCase()));
 

--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -43,7 +43,7 @@ function ago(iso: string | null) {
 
 export default function WorkshopBoardPage() {
   const [authed, setAuthed] = useState<boolean | null>(null);
-  const [canWrite, setCanWrite] = useState(false);
+  const [canWrite, setCanWrite] = useState<boolean | null>(null); // null = still checking; supervisors/admins only
   const [cards, setCards] = useState<Card[]>([]);
   const [memos, setMemos] = useState<Memo[]>([]);
   const [staffNames, setStaffNames] = useState<StaffName[]>([]);
@@ -67,9 +67,11 @@ export default function WorkshopBoardPage() {
       if (data.session) {
         const { data: w } = await supabase.rpc('is_board_writer');
         setCanWrite(w === true);
-        const { data: names } = await supabase.rpc('board_staff_names');
-        setStaffNames((names ?? []) as StaffName[]);
-      }
+        if (w === true) {
+          const { data: names } = await supabase.rpc('board_staff_names');
+          setStaffNames((names ?? []) as StaffName[]);
+        }
+      } else setCanWrite(false);
     })();
   }, []);
 
@@ -83,13 +85,13 @@ export default function WorkshopBoardPage() {
     setMemos((m ?? []) as Memo[]);
   }, []);
 
-  // Live board: refresh every 15s so every PC stays current without anyone pressing anything.
+  // Live board: refresh every 15s so every supervisor PC stays current.
   useEffect(() => {
-    if (!authed) return;
+    if (!authed || canWrite !== true) return;
     load();
     const t = setInterval(load, 15000);
     return () => clearInterval(t);
-  }, [authed, load]);
+  }, [authed, canWrite, load]);
 
   // One refresh for the whole workshop system: pull latest payment status from Niagawan
   // (so paid cars move to Done, new check-ins appear) AND reload the board now. The same
@@ -164,8 +166,9 @@ export default function WorkshopBoardPage() {
     return map;
   }, [cards]);
 
-  if (authed === null) return <div className="p-6 text-sm text-gray-500">Checking session…</div>;
+  if (authed === null || (authed && canWrite === null)) return <div className="p-6 text-sm text-gray-500">Checking session…</div>;
   if (!authed) return <div className="p-6 text-sm text-gray-600">Please sign in to see the workshop board.</div>;
+  if (!canWrite) return <div className="p-6 text-sm text-gray-600">The workshop board is for supervisors only.</div>;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-5">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,6 +14,7 @@ export default function NavBar() {
   const pathname = usePathname();
   const [email, setEmail] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  const [canBoard, setCanBoard] = useState<boolean>(false); // supervisor or admin -> sees Workshop
   const [counts, setCounts] = useState<{ mc: number; offday: number; po: number }>({ mc: 0, offday: 0, po: 0 });
   const [open, setOpen] = useState(false);
 
@@ -26,14 +27,18 @@ export default function NavBar() {
       if (userEmail) {
         const { data, error } = await supabase.rpc('is_admin');
         setIsAdmin(Boolean(data) && !error);
-      } else setIsAdmin(false);
+        const { data: bw } = await supabase.rpc('is_board_writer');
+        setCanBoard(bw === true);
+      } else { setIsAdmin(false); setCanBoard(false); }
     };
     readAuthAndRole();
     const { data } = supabase.auth.onAuthStateChange((_e, session) => {
       const userEmail = session?.user?.email ?? null;
       setEmail(userEmail);
-      if (userEmail) supabase.rpc('is_admin').then(({ data, error }) => setIsAdmin(Boolean(data) && !error));
-      else setIsAdmin(false);
+      if (userEmail) {
+        supabase.rpc('is_admin').then(({ data, error }) => setIsAdmin(Boolean(data) && !error));
+        supabase.rpc('is_board_writer').then(({ data }) => setCanBoard(data === true));
+      } else { setIsAdmin(false); setCanBoard(false); }
     });
     unsub = data?.subscription ?? null;
     return () => unsub?.unsubscribe();
@@ -70,8 +75,8 @@ export default function NavBar() {
 
   const mainLinks: NavItem[] = [
     { href: '/', label: 'Check-in' },
-    // The job board — visible to every signed-in staff PC, not just admins.
-    { href: '/workshop', label: 'Workshop' },
+    // The job board — supervisors and admins only.
+    ...(canBoard ? [{ href: '/workshop', label: 'Workshop' } as NavItem] : []),
   ];
   const adminLinks: NavItem[] = [
     { href: '/attendance/checkin', match: '/attendance', label: 'Attendance', badge: counts.mc + counts.offday },


### PR DESCRIPTION
Locks the whole workshop system to supervisors + admins (is_board_writer): board, Part Arrived, check-in. Nav link hidden for others; page guards added; job_cards/memos read + job_cards update RLS tightened from 'true' to is_board_writer.