### PR TITLE
feat(offday): required approve/reject reason, shown to staff

### DIFF
--- a/src/app/attendance/leave/page.tsx
+++ b/src/app/attendance/leave/page.tsx
@@ -10,6 +10,7 @@ type Req = {
   date_to: string;
   reason: string | null;
   status: 'pending' | 'approved' | 'rejected' | string;
+  review_note: string | null;
   created_at: string;
 };
 
@@ -63,9 +64,14 @@ export default function OffdayRequestsPage() {
   }, [reqs, staffF, statusF]);
 
   const decide = useCallback(async (id: string, approve: boolean) => {
+    const note = window.prompt(approve
+      ? 'Note for the staff (required) — e.g. "OK, approved":'
+      : 'Reason for rejecting (required) — e.g. "2 staff already off that date":');
+    if (note === null) return;                       // cancelled
+    if (!note.trim()) { alert('A reason is required.'); return; }
     setBusy(id);
-    const { error } = await supabase.rpc(approve ? 'approve_offday' : 'reject_offday', { p_id: id });
-    if (!error) await load();
+    const { error } = await supabase.rpc(approve ? 'approve_offday' : 'reject_offday', { p_id: id, p_note: note.trim() });
+    if (error) alert(error.message); else await load();
     setBusy(null);
   }, [load]);
 
@@ -109,6 +115,7 @@ export default function OffdayRequestsPage() {
                     </span>
                   </div>
                   {r.reason && <div className="text-xs text-gray-500">{r.reason}</div>}
+                  {r.review_note && <div className="mt-0.5 text-xs text-gray-400">📝 {r.review_note}</div>}
                 </div>
                 <div className="flex items-center gap-2">
                   {r.status === 'pending' ? (

--- a/src/components/CheckinV2.tsx
+++ b/src/components/CheckinV2.tsx
@@ -21,7 +21,7 @@ function fmtTime(t: string | null | undefined): string {
   return `${h}:${mm} ${ampm}`;
 }
 
-type OffReq = { id: string; date_from: string; date_to: string; reason: string | null; status: string; created_at: string };
+type OffReq = { id: string; date_from: string; date_to: string; reason: string | null; status: string; review_note: string | null; created_at: string };
 
 // 'YYYY-MM-DD' -> '15 Jun'
 function fmtDate(d: string): string {
@@ -101,7 +101,7 @@ export default function CheckinV2() {
   const loadOff = useCallback(async () => {
     if (!email) return;
     const { data } = await supabase.from('offday_requests')
-      .select('id,date_from,date_to,reason,status,created_at')
+      .select('id,date_from,date_to,reason,status,review_note,created_at')
       .eq('staff_email', email).order('created_at', { ascending: false }).limit(8);
     setMyOff((data ?? []) as OffReq[]);
   }, [email]);
@@ -297,12 +297,19 @@ export default function CheckinV2() {
           <div className="text-sm font-medium text-slate-700">🌴 My off-day requests</div>
           <div className="mt-2 space-y-1.5">
             {myOff.map((r) => (
-              <div key={r.id} className="flex items-center justify-between gap-2 text-sm">
-                <div className="min-w-0">
-                  <div className="text-slate-800">{r.date_from === r.date_to ? fmtDate(r.date_from) : `${fmtDate(r.date_from)} – ${fmtDate(r.date_to)}`}</div>
-                  {r.reason && <div className="truncate text-xs text-slate-400">{r.reason}</div>}
+              <div key={r.id} className="text-sm">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="text-slate-800">{r.date_from === r.date_to ? fmtDate(r.date_from) : `${fmtDate(r.date_from)} – ${fmtDate(r.date_to)}`}</div>
+                    {r.reason && <div className="truncate text-xs text-slate-400">{r.reason}</div>}
+                  </div>
+                  <span className={offStatusChip(r.status)}>{offStatusLabel(r.status)}</span>
                 </div>
-                <span className={offStatusChip(r.status)}>{offStatusLabel(r.status)}</span>
+                {r.review_note && (
+                  <div className={`mt-1 rounded-md px-2 py-1 text-xs ${(r.status || '').toLowerCase() === 'rejected' ? 'bg-rose-50 text-rose-700' : 'bg-emerald-50 text-emerald-700'}`}>
+                    {(r.status || '').toLowerCase() === 'rejected' ? 'Reason: ' : 'Note: '}{r.review_note}
+                  </div>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
Admin enters a required reason on approve/reject; staff see it on their My off-day requests card. RPCs approve_offday/reject_offday now take p_note -> offday_requests.review_note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)