### PR TITLE
feat(advance): salary advance requests + payroll auto-deduct

### DIFF
--- a/src/app/attendance/advance/page.tsx
+++ b/src/app/attendance/advance/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+type Req = {
+  id: string;
+  staff_email: string;
+  amount: number;
+  reason: string | null;
+  status: 'pending' | 'approved' | 'rejected' | string;
+  review_note: string | null;
+  credit_by: string | null;
+  requested_at: string;
+};
+
+const rm = (n: number | null) => `RM${Number(n || 0).toLocaleString('en-MY', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtD = (d: string | null) => { if (!d) return ''; const [y, m, dd] = d.split('-'); return `${dd}/${m}/${y}`; };
+
+export default function AdvanceRequestsPage() {
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [reqs, setReqs] = useState<Req[]>([]);
+  const [names, setNames] = useState<Map<string, string>>(new Map());
+  const [busy, setBusy] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [statusF, setStatusF] = useState('all');
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      setAuthed(!!data.session);
+      if (data.session) { const { data: ok } = await supabase.rpc('is_admin'); setIsAdmin(ok === true); }
+      else setIsAdmin(false);
+    })();
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [{ data: r }, { data: s }] = await Promise.all([
+      supabase.from('advance_requests').select('*').order('requested_at', { ascending: false }),
+      supabase.from('staff').select('email,name'),
+    ]);
+    setReqs((r ?? []) as Req[]);
+    const m = new Map<string, string>();
+    (s ?? []).forEach((x: { email: string; name: string | null }) => m.set(x.email.toLowerCase(), x.name ?? x.email));
+    setNames(m);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { if (isAdmin) load(); }, [isAdmin, load]);
+
+  const filtered = useMemo(() => {
+    const rank = (s: string) => (s === 'pending' ? 0 : 1);
+    return [...reqs]
+      .sort((a, b) => rank(a.status) - rank(b.status) || b.requested_at.localeCompare(a.requested_at))
+      .filter((r) => statusF === 'all' || r.status === statusF);
+  }, [reqs, statusF]);
+
+  const decide = useCallback(async (id: string, approve: boolean) => {
+    const note = window.prompt(approve
+      ? 'Note for the staff (required) — e.g. "Approved, credited Wed":'
+      : 'Reason for rejecting (required) — e.g. "requested before the 15th":');
+    if (note === null) return;
+    if (!note.trim()) { alert('A reason is required.'); return; }
+    setBusy(id);
+    const { error } = await supabase.rpc(approve ? 'approve_advance' : 'reject_advance', { p_id: id, p_note: note.trim() });
+    if (error) alert(error.message); else await load();
+    setBusy(null);
+  }, [load]);
+
+  if (authed === null || isAdmin === null) return <div className="text-sm text-gray-500">Checking…</div>;
+  if (!authed) return <div className="text-sm text-gray-600">Please sign in.</div>;
+  if (!isAdmin) return <div className="text-sm text-gray-600">This page is for admins only.</div>;
+
+  const pending = reqs.filter((r) => r.status === 'pending').length;
+
+  return (
+    <div>
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <span className="text-sm text-gray-600">{pending} pending</span>
+        <select value={statusF} onChange={(e) => setStatusF(e.target.value)} className="rounded-md border border-gray-300 px-2 py-1.5 text-sm">
+          <option value="all">All statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+        <button onClick={load} disabled={loading} className="ml-auto rounded-md border border-gray-300 px-2.5 py-1.5 text-xs text-gray-600 hover:bg-gray-50 disabled:opacity-50">
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+      <p className="mb-3 text-xs text-gray-400">Approving posts an <b>ADVANCE deduction</b> to that month&apos;s payslip and sets the credit-by date (+2 working days).</p>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center text-sm text-gray-500">No advance requests.</div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((r) => (
+            <div key={r.id} className={`rounded-lg border p-3 ${r.status === 'pending' ? 'border-amber-200 bg-amber-50/40' : 'border-gray-200 bg-white'}`}>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="text-sm font-medium text-gray-900">
+                    {names.get(r.staff_email.toLowerCase()) ?? r.staff_email}
+                    <span className="ml-2 text-sm font-bold text-gray-900">{rm(r.amount)}</span>
+                  </div>
+                  {r.reason && <div className="text-xs text-gray-500">{r.reason}</div>}
+                  {r.review_note && <div className="mt-0.5 text-xs text-gray-400">📝 {r.review_note}</div>}
+                  {r.status === 'approved' && r.credit_by && <div className="mt-0.5 text-xs font-medium text-emerald-600">Credit by {fmtD(r.credit_by)}</div>}
+                </div>
+                <div className="flex items-center gap-2">
+                  {r.status === 'pending' ? (
+                    <>
+                      <button onClick={() => decide(r.id, true)} disabled={busy === r.id} className="rounded-md bg-emerald-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50">
+                        {busy === r.id ? '…' : 'Approve'}
+                      </button>
+                      <button onClick={() => decide(r.id, false)} disabled={busy === r.id} className="rounded-md border border-gray-200 px-2.5 py-1 text-xs text-gray-500 hover:bg-gray-100 disabled:opacity-50">Reject</button>
+                    </>
+                  ) : (
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${r.status === 'approved' ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-700'}`}>
+                      {r.status === 'approved' ? 'Approved ✓' : 'Rejected'}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/attendance/layout.tsx
+++ b/src/app/attendance/layout.tsx
@@ -11,6 +11,7 @@ const TABS = [
   { href: '/attendance/report', label: 'Report' },
   { href: '/attendance/offday', label: 'Off-day' },
   { href: '/attendance/leave', label: 'Off-day req' },
+  { href: '/attendance/advance', label: 'Advance' },
   { href: '/attendance/mc', label: 'MC' },
   { href: '/attendance/settings', label: 'Settings' },
 ];

--- a/src/components/CheckinV2.tsx
+++ b/src/components/CheckinV2.tsx
@@ -37,6 +37,9 @@ function offStatusChip(s: string): string {
   const x = (s || '').toLowerCase();
   return 'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ' + (x === 'approved' ? 'bg-emerald-100 text-emerald-700' : x === 'rejected' ? 'bg-rose-100 text-rose-700' : 'bg-amber-100 text-amber-800');
 }
+const rm = (n: number | null) => `RM${Number(n || 0).toLocaleString('en-MY', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+type AdvReq = { id: string; amount: number; reason: string | null; status: string; review_note: string | null; credit_by: string | null; requested_at: string };
+type AdvLimit = { cap: number; eligible_today: boolean; already_requested: boolean; day: number };
 
 function haversineM(aLat: number, aLon: number, bLat: number, bLon: number): number {
   const R = 6371000;
@@ -73,6 +76,13 @@ export default function CheckinV2() {
   const [offBusy, setOffBusy] = useState(false);
   const [offMsg, setOffMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
   const [myOff, setMyOff] = useState<OffReq[]>([]);
+  const [showAdv, setShowAdv] = useState(false);
+  const [advAmount, setAdvAmount] = useState('');
+  const [advReason, setAdvReason] = useState('');
+  const [advBusy, setAdvBusy] = useState(false);
+  const [advMsg, setAdvMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  const [advLimit, setAdvLimit] = useState<AdvLimit | null>(null);
+  const [myAdv, setMyAdv] = useState<AdvReq[]>([]);
 
   useEffect(() => {
     setNow(new Date());
@@ -107,6 +117,18 @@ export default function CheckinV2() {
   }, [email]);
 
   useEffect(() => { if (email) loadOff(); }, [email, loadOff]);
+
+  const loadAdv = useCallback(async () => {
+    if (!email) return;
+    const [{ data: lim }, { data: rows }] = await Promise.all([
+      supabase.rpc('my_advance_limit'),
+      supabase.from('advance_requests').select('id,amount,reason,status,review_note,credit_by,requested_at').ilike('staff_email', email).order('requested_at', { ascending: false }).limit(6),
+    ]);
+    if (lim) setAdvLimit(lim as AdvLimit);
+    setMyAdv((rows ?? []) as AdvReq[]);
+  }, [email]);
+
+  useEffect(() => { if (email) loadAdv(); }, [email, loadAdv]);
 
   // Not signed in → send to the branded login page.
   useEffect(() => { if (email === null) router.replace('/login'); }, [email, router]);
@@ -178,6 +200,17 @@ export default function CheckinV2() {
     if (error) setOffMsg({ kind: 'err', text: error.message });
     else { setOffMsg({ kind: 'ok', text: 'Off-day request sent ✓ — waiting for approval.' }); setOffFrom(''); setOffTo(''); setOffReason(''); loadOff(); }
     setOffBusy(false);
+  };
+
+  const submitAdv = async () => {
+    if (!email) return;
+    const amt = Number(advAmount);
+    if (!amt || amt <= 0) { setAdvMsg({ kind: 'err', text: 'Enter an amount.' }); return; }
+    setAdvBusy(true); setAdvMsg(null);
+    const { error } = await supabase.rpc('request_advance', { p_amount: amt, p_reason: advReason || null });
+    if (error) setAdvMsg({ kind: 'err', text: error.message });
+    else { setAdvMsg({ kind: 'ok', text: 'Advance request sent ✓ — waiting for approval.' }); setAdvAmount(''); setAdvReason(''); loadAdv(); }
+    setAdvBusy(false);
   };
 
   if (email === undefined || email === null)
@@ -302,6 +335,62 @@ export default function CheckinV2() {
                   <div className="min-w-0">
                     <div className="text-slate-800">{r.date_from === r.date_to ? fmtDate(r.date_from) : `${fmtDate(r.date_from)} – ${fmtDate(r.date_to)}`}</div>
                     {r.reason && <div className="truncate text-xs text-slate-400">{r.reason}</div>}
+                  </div>
+                  <span className={offStatusChip(r.status)}>{offStatusLabel(r.status)}</span>
+                </div>
+                {r.review_note && (
+                  <div className={`mt-1 rounded-md px-2 py-1 text-xs ${(r.status || '').toLowerCase() === 'rejected' ? 'bg-rose-50 text-rose-700' : 'bg-emerald-50 text-emerald-700'}`}>
+                    {(r.status || '').toLowerCase() === 'rejected' ? 'Reason: ' : 'Note: '}{r.review_note}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Request salary advance */}
+      <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <button onClick={() => setShowAdv((v) => !v)} className="flex w-full items-center justify-between text-sm font-medium text-slate-700">
+          <span>💵 Request salary advance</span>
+          <span className="text-slate-400">{showAdv ? '−' : '+'}</span>
+        </button>
+        {showAdv && (
+          <div className="mt-3 space-y-2 text-sm">
+            {advLimit && (
+              <div className="rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600">Max this month: <span className="font-semibold text-slate-900">{rm(advLimit.cap)}</span> · 15 days&apos; salary</div>
+            )}
+            {advLimit && !advLimit.eligible_today ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">Advances can be requested from the 15th of the month onward.</div>
+            ) : advLimit && advLimit.already_requested ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">You already have an advance request this month.</div>
+            ) : (
+              <>
+                <label className="block text-xs text-slate-500">Amount (RM)
+                  <input type="number" inputMode="decimal" value={advAmount} onChange={(e) => setAdvAmount(e.target.value)} placeholder="e.g. 500" className="mt-0.5 block w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm" />
+                </label>
+                <label className="block text-xs text-slate-500">Reason (optional)
+                  <input value={advReason} onChange={(e) => setAdvReason(e.target.value)} placeholder="e.g. medical bill" className="mt-0.5 block w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm" />
+                </label>
+                <button onClick={submitAdv} disabled={advBusy} className="w-full rounded-lg bg-brand-700 py-2.5 text-sm font-semibold text-white hover:bg-brand-800 disabled:opacity-50">{advBusy ? 'Sending…' : 'Request advance'}</button>
+              </>
+            )}
+            {advMsg && <div className={`rounded-md border p-2 text-sm ${advMsg.kind === 'ok' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-rose-200 bg-rose-50 text-rose-800'}`}>{advMsg.text}</div>}
+          </div>
+        )}
+      </div>
+
+      {/* My advance requests */}
+      {myAdv.length > 0 && (
+        <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="text-sm font-medium text-slate-700">💵 My advance requests</div>
+          <div className="mt-2 space-y-1.5">
+            {myAdv.map((r) => (
+              <div key={r.id} className="text-sm">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="text-slate-800">{rm(r.amount)}{r.reason ? ` · ${r.reason}` : ''}</div>
+                    {r.status === 'approved' && r.credit_by && <div className="text-xs text-emerald-600">credited by {fmtDate(r.credit_by)}</div>}
                   </div>
                   <span className={offStatusChip(r.status)}>{offStatusLabel(r.status)}</span>
                 </div>


### PR DESCRIPTION
Staff request a salary advance (max = basic_salary/26*15 per EA1955; from the 15th onward; one per month). Admin approves on Attendance > Advance; approval posts an ADVANCE deduction to that month's payslip + sets credit-by (+2 working days). Reason required on approve/reject; staff see status/reason/credit date.

Backend verified via rollback test (approve posts the deduction, credit-by correct, nothing leaked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)