### PR TITLE
feat(notify): notification bell + dropdown (Facebook-style)

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,18 +5,34 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useEffect, useMemo, useState } from 'react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 
 type NavItem = { href: string; label: string; match?: string; badge?: number };
+type NotifItem = { type: string; id: string; who: string; detail: string; when: string; href: string };
+const NOTIF_ICON: Record<string, string> = { offday: '🌴', advance: '💵', mc: '📄' };
+const NOTIF_LABEL: Record<string, string> = { offday: 'off-day request', advance: 'advance request', mc: 'MC' };
+function relTime(iso: string): string {
+  const m = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 60000));
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
 
 export default function NavBar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [email, setEmail] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [canBoard, setCanBoard] = useState<boolean>(false); // supervisor or admin -> sees Workshop
   const [counts, setCounts] = useState<{ mc: number; offday: number; advance: number; po: number }>({ mc: 0, offday: 0, advance: 0, po: 0 });
+  const [items, setItems] = useState<NotifItem[]>([]);
+  const [bellOpen, setBellOpen] = useState(false);
+  const [seenAt, setSeenAt] = useState<string>('');
   const [open, setOpen] = useState(false);
+  useEffect(() => { setSeenAt(localStorage.getItem('notif_seen_at') || ''); }, []);
 
   useEffect(() => {
     let unsub: { unsubscribe: () => void } | null = null;
@@ -45,25 +61,36 @@ export default function NavBar() {
   }, []);
 
   useEffect(() => {
-    if (!isAdmin) { setCounts({ mc: 0, offday: 0, advance: 0, po: 0 }); return; }
+    if (!isAdmin) { setCounts({ mc: 0, offday: 0, advance: 0, po: 0 }); setItems([]); return; }
     let active = true;
     const load = async () => {
       const { data } = await supabase.rpc('notification_counts');
       const d = (data ?? {}) as { mc?: number; offday?: number; advance?: number; po?: number };
       if (active) setCounts({ mc: d.mc ?? 0, offday: d.offday ?? 0, advance: d.advance ?? 0, po: d.po ?? 0 });
+      const { data: it } = await supabase.rpc('notification_items');
+      if (active) setItems((Array.isArray(it) ? it : []) as NotifItem[]);
     };
     load();
     const id = setInterval(load, 60000);
     return () => { active = false; clearInterval(id); };
   }, [isAdmin, pathname]);
 
-  // Close the mobile drawer whenever the route changes.
-  useEffect(() => { setOpen(false); }, [pathname]);
+  // Close the mobile drawer / notifications whenever the route changes.
+  useEffect(() => { setOpen(false); setBellOpen(false); }, [pathname]);
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
     window.location.reload();
   };
+
+  const openBell = () => {
+    setBellOpen((v) => {
+      if (!v) { const now = new Date().toISOString(); setSeenAt(now); try { localStorage.setItem('notif_seen_at', now); } catch {} }
+      return !v;
+    });
+  };
+  const goTo = (href: string) => { setBellOpen(false); router.push(href); };
+  const unseen = items.filter((i) => !seenAt || i.when > seenAt).length;
 
   const isActive = useMemo(
     () => (item: NavItem) => {
@@ -126,6 +153,37 @@ export default function NavBar() {
 
         {/* Right side */}
         <div className="flex shrink-0 items-center gap-2">
+          {email && isAdmin && (
+            <div className="relative">
+              <button onClick={openBell} aria-label="Notifications" className="relative inline-flex h-10 w-10 items-center justify-center rounded-md text-slate-700 hover:bg-slate-100">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" /></svg>
+                {unseen > 0 && <span className="absolute right-1 top-1 inline-flex min-w-[16px] items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-semibold leading-4 text-white">{unseen}</span>}
+              </button>
+              {bellOpen && (
+                <>
+                  <button className="fixed inset-0 z-40 cursor-default" aria-label="Close notifications" onClick={() => setBellOpen(false)} />
+                  <div className="absolute right-0 z-50 mt-1 w-80 max-w-[88vw] overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg">
+                    <div className="border-b border-slate-100 px-3 py-2 text-sm font-semibold text-slate-700">Notifications</div>
+                    <div className="max-h-96 overflow-y-auto">
+                      {items.length === 0 ? (
+                        <div className="px-3 py-6 text-center text-sm text-slate-400">Nothing pending</div>
+                      ) : (
+                        items.map((i) => (
+                          <button key={i.type + i.id} onClick={() => goTo(i.href)} className="flex w-full items-start gap-2 border-b border-slate-50 px-3 py-2 text-left hover:bg-slate-50">
+                            <span className="mt-0.5 text-base leading-none">{NOTIF_ICON[i.type] ?? '🔔'}</span>
+                            <span className="min-w-0 flex-1">
+                              <span className="block text-sm text-slate-800"><span className="font-medium">{i.who}</span> · {NOTIF_LABEL[i.type] ?? i.type}</span>
+                              <span className="block truncate text-xs text-slate-500">{i.detail} · {relTime(i.when)}</span>
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
           {email ? (
             <>
               <span className="hidden max-w-[180px] truncate text-sm text-slate-500 xl:inline">{email}</span>


### PR DESCRIPTION
Admin nav bell with unread count + dropdown of pending off-day/advance/MC requests, each linking to its approval tab. Unread clears on open (localStorage). New notification_items() RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)