### PR TITLE
fix(inventory): tolerate X 70 / X-70 spacing + force clean deploy

### DIFF
--- a/src/app/niagawan/inventory/page.tsx
+++ b/src/app/niagawan/inventory/page.tsx
@@ -40,9 +40,9 @@ function guessCategory(descp: string | null): string {
   if (d.includes('LIQUI')) return 'Oil - Liquimoly';
   if (d.includes('GULF')) return 'Oil - Gulf';
   if (d.includes('SHELL')) return 'Oil - Shell';
-  if (/\bX70\b/.test(d)) return 'Proton X70';
-  if (/\bX50\b/.test(d)) return 'Proton X50';
-  if (/\bS70\b/.test(d)) return 'Proton S70';
+  if (/\bX[\s-]?70\b/.test(d)) return 'Proton X70';
+  if (/\bX[\s-]?50\b/.test(d)) return 'Proton X50';
+  if (/\bS[\s-]?70\b/.test(d)) return 'Proton S70';
   return 'Other';
 }
 


### PR DESCRIPTION
Matches 'X 70' / 'X-70' / 'S 70' spacing variants in the new-item category auto-detect (previously only bare 'X70'). Also serves to force a clean production build: PR #128 merged but Vercel only built it as a preview (the squash landed mid-preview-build and was never promoted to production). tsc passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)