### PR TITLE
fix(pinv): token-aware product matching (combined/truncated codes)

### DIFF
--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -127,12 +127,17 @@ export default function ReviewInvoicePage() {
     setCandsLoaded(false);
     (async () => {
       if (!allCodes.length) { if (!cancelled) { setCatMatches({}); setCandsLoaded(true); } return; }
-      const { data } = await supabase.from('niagawan_products').select('sku,code,descp,price').in('code', allCodes);
+      // Token-aware match: pinv_candidates splits each product's code on spaces/commas and matches
+      // any normalised token — so a combined code like "M1515-10040 M1515-A0110" is found by "M1515-10040".
+      const { data } = await supabase.rpc('pinv_candidates', { p_codes: allCodes });
       if (cancelled) return;
       const map: Record<string, NiagawanMatch[]> = {};
       ((data ?? []) as Array<{ sku: string; code: string; descp: string | null; price: number | string | null }>).forEach((p) => {
-        const k = normCode(p.code); if (!k) return;
-        (map[k] = map[k] || []).push({ sku: String(p.sku), code: String(p.code), descp: String(p.descp ?? ''), price: String(p.price ?? ''), bal: '' });
+        const m: NiagawanMatch = { sku: String(p.sku), code: String(p.code), descp: String(p.descp ?? ''), price: String(p.price ?? ''), bal: '' };
+        // Index the product under EVERY token of its code, so a line code matches it via that token.
+        Array.from(new Set(String(p.code ?? '').split(/[\s,]+/).map(normCode).filter(Boolean))).forEach((k) => {
+          (map[k] = map[k] || []).push(m);
+        });
       });
       setCatMatches(map); setCandsLoaded(true);
     })();


### PR DESCRIPTION
An existing product with a COMBINED code (e.g. 'M1515-10040 M1515-A0110') was missed by exact matching and shown as 'create new' (duplicate risk; caught in testing). Adds pinv_candidates RPC (token-split normalised match), review page uses it and indexes by code token, and the NAS dup-guard is token-aware too. Migration applied; tsc + node --check pass; NAS deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)