### PR TITLE
feat(attendance): half-day support (PR1 — engine + admin + board/report)

### DIFF
--- a/src/app/attendance/offday/page.tsx
+++ b/src/app/attendance/offday/page.tsx
@@ -19,9 +19,12 @@ const STATUSES = [
   { value: 'PH', label: 'Public holiday (government)' },
   { value: 'MC', label: 'Medical leave (MC)' },
   { value: 'ABSENT', label: 'Absent' },
+  { value: 'HALF_AM', label: 'Half day — morning (9:30–1:30)' },
+  { value: 'HALF_PM', label: 'Half day — afternoon (1:30–6:00)' },
 ];
 const STATUS_LABEL: Record<string, string> = {
   OFFDAY: 'Off day', PH: 'Public holiday', MC: 'MC', ABSENT: 'Absent',
+  HALF_AM: 'Half day (AM)', HALF_PM: 'Half day (PM)',
 };
 
 export default function AttendanceOffdayPage() {
@@ -67,13 +70,16 @@ export default function AttendanceOffdayPage() {
     const start = `${y}-${String(m).padStart(2, '0')}-01`;
     const endD = new Date(y, m, 1);
     const end = `${endD.getFullYear()}-${String(endD.getMonth() + 1).padStart(2, '0')}-01`;
-    const { data } = await supabase
-      .from('day_status')
-      .select('day,staff_email,status,note')
-      .gte('day', start)
-      .lt('day', end)
-      .order('day', { ascending: false });
-    setExisting((data ?? []) as DSRow[]);
+    const [{ data: ds }, { data: dh }] = await Promise.all([
+      supabase.from('day_status').select('day,staff_email,status,note').gte('day', start).lt('day', end),
+      supabase.from('day_half').select('day,staff_email,half,note').gte('day', start).lt('day', end),
+    ]);
+    const merged: DSRow[] = [
+      ...((ds ?? []) as DSRow[]),
+      ...((dh ?? []) as Array<{ day: string; staff_email: string; half: string; note: string | null }>)
+        .map((h) => ({ day: h.day, staff_email: h.staff_email, status: `HALF_${h.half}`, note: h.note })),
+    ].sort((a, b) => (a.day < b.day ? 1 : -1));
+    setExisting(merged);
   }, [from]);
 
   useEffect(() => {
@@ -95,9 +101,16 @@ export default function AttendanceOffdayPage() {
     if (!from || !to || from > to) { setMsg({ kind: 'err', text: 'Pick a valid date range.' }); return; }
     setBusy(true); setMsg(null);
     try {
+      const isHalf = status === 'HALF_AM' || status === 'HALF_PM';
+      const half = status === 'HALF_PM' ? 'PM' : 'AM';
       const days = eachDay(from, to);
       for (const d of days) {
-        if (who === 'ALL') {
+        if (isHalf) {
+          const { error } = who === 'ALL'
+            ? await supabase.rpc('set_day_half_all', { p_day: d, p_half: half, p_note: note || null })
+            : await supabase.rpc('set_day_half', { p_email: who, p_day: d, p_half: half, p_note: note || null });
+          if (error) throw error;
+        } else if (who === 'ALL') {
           const { error } = await supabase.rpc('set_day_status_all', { p_day: d, p_status: status, p_note: note || null });
           if (error) throw error;
         } else {
@@ -106,7 +119,7 @@ export default function AttendanceOffdayPage() {
         }
       }
       await supabase.rpc('attendance_v2_recompute', { p_from: from, p_to: to });
-      setMsg({ kind: 'ok', text: `Set ${status} for ${days.length} day(s).` });
+      setMsg({ kind: 'ok', text: `Set ${STATUS_LABEL[status] ?? status} for ${days.length} day(s).` });
       setNote('');
       await loadExisting();
     } catch (e: any) {
@@ -119,7 +132,10 @@ export default function AttendanceOffdayPage() {
   const clearOne = useCallback(async (r: DSRow) => {
     setBusy(true); setMsg(null);
     try {
-      const { error } = await supabase.from('day_status').delete().eq('day', r.day).eq('staff_email', r.staff_email);
+      const isHalf = r.status === 'HALF_AM' || r.status === 'HALF_PM';
+      const { error } = isHalf
+        ? await supabase.rpc('clear_day_half', { p_email: r.staff_email, p_day: r.day })
+        : await supabase.from('day_status').delete().eq('day', r.day).eq('staff_email', r.staff_email);
       if (error) throw error;
       await supabase.rpc('attendance_v2_recompute', { p_from: r.day, p_to: r.day });
       await loadExisting();

--- a/src/app/attendance/report/page.tsx
+++ b/src/app/attendance/report/page.tsx
@@ -11,6 +11,7 @@ type Row = {
   check_in_kl: string | null;  // 'HH:MM'
   check_out_kl: string | null; // 'HH:MM'
   late_min: number | null;
+  half: 'AM' | 'PM' | null;
 };
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -227,6 +228,7 @@ export default function AttendanceReportPage() {
                       {r.status === 'OFFDAY' && <span className="text-blue-700">Off day</span>}
                       {r.status === 'PH' && <span className="text-indigo-700">Public holiday</span>}
                       {r.status === 'MC' && <span className="text-blue-700">MC</span>}
+                      {r.half && <span className="ml-1 rounded-full bg-sky-50 px-1.5 py-0.5 text-xs font-medium text-sky-700" title={r.half === 'AM' ? 'Half day · morning (9:30–1:30)' : 'Half day · afternoon (1:30–6:00)'}>½ {r.half}</span>}
                     </td>
                     <td className="px-3 py-2 text-gray-700">{fmt12(r.check_in_kl)}</td>
                     <td className="px-3 py-2 text-gray-700">{fmt12(r.check_out_kl)}</td>

--- a/src/app/attendance/today/page.tsx
+++ b/src/app/attendance/today/page.tsx
@@ -11,6 +11,7 @@ type Row = {
   check_in_kl: string | null;
   check_out_kl: string | null;
   late_min: number | null;
+  half: 'AM' | 'PM' | null;
 };
 
 function fmtTime(t: string | null | undefined): string {
@@ -33,6 +34,7 @@ function klNowMinutes(): number {
 }
 
 const DEFAULT_START_MIN = 9 * 60 + 30; // 09:30 default start
+const PM_HALF_START_MIN = 13 * 60 + 30; // afternoon half-day expects 1:30pm
 const GRACE_MIN = 60; // "Absent" shows 1 hour after each person's start
 
 export default function AttendanceTodayPage() {
@@ -91,10 +93,13 @@ export default function AttendanceTodayPage() {
     });
   }, [isAdmin]);
 
-  const cutoffFor = useCallback(
-    (emailAddr: string) => (startByEmail.get(emailAddr) ?? DEFAULT_START_MIN) + GRACE_MIN,
+  // Expected start (minutes) — an afternoon half-day expects 1:30pm, else the staff's normal start.
+  const expStartFor = useCallback(
+    (r: Row) => (r.half === 'PM' ? PM_HALF_START_MIN : (startByEmail.get(r.staff_email) ?? DEFAULT_START_MIN)),
     [startByEmail]
   );
+  // "Absent" only shows 1 hour after the expected start (so an afternoon half-day isn't flagged in the morning).
+  const cutoffFor = useCallback((r: Row) => expStartFor(r) + GRACE_MIN, [expStartFor]);
 
   const counts = useMemo(() => {
     const nowMin = klNowMinutes();
@@ -105,7 +110,7 @@ export default function AttendanceTodayPage() {
         present++;
         if ((r.late_min ?? 0) > 0) late++;
       } else if (r.status === 'ABSENT') {
-        if (nowMin >= cutoffFor(r.staff_email)) absent++;
+        if (nowMin >= cutoffFor(r)) absent++;
         else notYet++;
       }
     }
@@ -160,9 +165,10 @@ export default function AttendanceTodayPage() {
             {rows.map((r) => {
               const isAbsent = r.status === 'ABSENT';
               const nowMin = klNowMinutes();
-              const showAbsent = isAbsent && nowMin >= cutoffFor(r.staff_email);
-              const showNotYet = isAbsent && nowMin < cutoffFor(r.staff_email);
+              const showAbsent = isAbsent && nowMin >= cutoffFor(r);
+              const showNotYet = isAbsent && nowMin < cutoffFor(r);
               const isLate = r.status === 'PRESENT' && (r.late_min ?? 0) > 0;
+              const halfLabel = r.half === 'AM' ? 'Half day · AM (9:30–1:30)' : r.half === 'PM' ? 'Half day · PM (1:30–6:00)' : null;
               return (
                 <tr key={r.staff_email} className="border-t border-gray-100">
                   <td className="px-3 py-2 text-gray-900">{r.display_name ?? r.staff_email}</td>
@@ -174,6 +180,7 @@ export default function AttendanceTodayPage() {
                     {(r.status === 'OFFDAY' || r.status === 'MC') && <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">{r.status === 'OFFDAY' ? 'Off day' : 'MC'}</span>}
                     {showAbsent && <span className="rounded-full bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700">Absent</span>}
                     {showNotYet && <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">Not in yet</span>}
+                    {halfLabel && <span className="ml-1 rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-700" title={halfLabel}>½ {r.half}</span>}
                   </td>
                   <td className="px-3 py-2 text-gray-700">{fmtTime(r.check_in_kl)}</td>
                   <td className="px-3 py-2 text-gray-700">{fmtTime(r.check_out_kl)}</td>


### PR DESCRIPTION
Half-day = shift modifier (AM 9:30-1:30 / PM 1:30-6:00) in a new day_half marker; recompute shifts expected start to 1:30pm for PM so the board stops false Late/Absent. Full pay. Admin sets it in the Off-day tab; Today + Report label it. DB migrations already applied + advisor-clean (0 ERROR). PR2 (staff request + notifications) follows. tsc passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)