### PR TITLE
feat(attendance): staff half-day request flow + notifications (PR2)

### DIFF
--- a/src/app/attendance/halfday-req/page.tsx
+++ b/src/app/attendance/halfday-req/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+type Req = {
+  id: string;
+  staff_email: string;
+  date_from: string;
+  date_to: string;
+  half: 'AM' | 'PM' | string;
+  reason: string | null;
+  status: 'pending' | 'approved' | 'rejected' | string;
+  review_note: string | null;
+  created_at: string;
+};
+
+const fmtD = (d: string) => { const [y, m, dd] = d.split('-'); return `${dd}/${m}/${y}`; };
+const halfLabel = (h: string) => (h === 'PM' ? 'PM (1:30–6:00)' : 'AM (9:30–1:30)');
+
+export default function HalfdayRequestsPage() {
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [reqs, setReqs] = useState<Req[]>([]);
+  const [names, setNames] = useState<Map<string, string>>(new Map());
+  const [busy, setBusy] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [staffF, setStaffF] = useState('ALL');
+  const [statusF, setStatusF] = useState('all');
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      setAuthed(!!data.session);
+      if (data.session) { const { data: ok } = await supabase.rpc('is_admin'); setIsAdmin(ok === true); }
+      else setIsAdmin(false);
+    })();
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [{ data: r }, { data: s }] = await Promise.all([
+      supabase.from('halfday_requests').select('*').order('created_at', { ascending: false }),
+      supabase.from('staff').select('email,name'),
+    ]);
+    setReqs((r ?? []) as Req[]);
+    const m = new Map<string, string>();
+    (s ?? []).forEach((x: { email: string; name: string | null }) => m.set(x.email.toLowerCase(), x.name ?? x.email));
+    setNames(m);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { if (isAdmin) load(); }, [isAdmin, load]);
+
+  const staffList = useMemo(() => {
+    const m = new Map<string, string>();
+    reqs.forEach((r) => m.set(r.staff_email, names.get(r.staff_email.toLowerCase()) ?? r.staff_email));
+    return [...m.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+  }, [reqs, names]);
+
+  const filtered = useMemo(() => {
+    const rank = (s: string) => (s === 'pending' ? 0 : 1);
+    return [...reqs]
+      .sort((a, b) => rank(a.status) - rank(b.status) || b.created_at.localeCompare(a.created_at))
+      .filter((r) => (staffF === 'ALL' || r.staff_email === staffF) && (statusF === 'all' || r.status === statusF));
+  }, [reqs, staffF, statusF]);
+
+  const decide = useCallback(async (id: string, approve: boolean) => {
+    const note = window.prompt(approve
+      ? 'Note for the staff (required) — e.g. "OK, approved":'
+      : 'Reason for rejecting (required) — e.g. "we need full staff that day":');
+    if (note === null) return;
+    if (!note.trim()) { alert('A reason is required.'); return; }
+    setBusy(id);
+    const { error } = await supabase.rpc(approve ? 'approve_halfday' : 'reject_halfday', { p_id: id, p_note: note.trim() });
+    if (error) alert(error.message); else await load();
+    setBusy(null);
+  }, [load]);
+
+  if (authed === null || isAdmin === null) return <div className="text-sm text-gray-500">Checking…</div>;
+  if (!authed) return <div className="text-sm text-gray-600">Please sign in.</div>;
+  if (!isAdmin) return <div className="text-sm text-gray-600">This page is for admins only.</div>;
+
+  const pending = reqs.filter((r) => r.status === 'pending').length;
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <span className="text-sm text-gray-600">{pending} pending</span>
+        <select value={staffF} onChange={(e) => setStaffF(e.target.value)} className="ml-2 rounded-md border border-gray-300 px-2 py-1.5 text-sm">
+          <option value="ALL">All staff</option>
+          {staffList.map(([email, name]) => <option key={email} value={email}>{name}</option>)}
+        </select>
+        <select value={statusF} onChange={(e) => setStatusF(e.target.value)} className="rounded-md border border-gray-300 px-2 py-1.5 text-sm">
+          <option value="all">All statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+        <button onClick={load} disabled={loading} className="ml-auto rounded-md border border-gray-300 px-2.5 py-1.5 text-xs text-gray-600 hover:bg-gray-50 disabled:opacity-50">
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center text-sm text-gray-500">No half-day requests.</div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((r) => (
+            <div key={r.id} className={`rounded-lg border p-3 ${r.status === 'pending' ? 'border-amber-200 bg-amber-50/40' : 'border-gray-200 bg-white'}`}>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="text-sm font-medium text-gray-900">
+                    {names.get(r.staff_email.toLowerCase()) ?? r.staff_email}
+                    <span className="ml-2 rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-700">½ {halfLabel(r.half)}</span>
+                    <span className="ml-2 text-xs font-normal text-gray-500">
+                      {fmtD(r.date_from)}{r.date_to !== r.date_from ? ` – ${fmtD(r.date_to)}` : ''}
+                    </span>
+                  </div>
+                  {r.reason && <div className="text-xs text-gray-500">{r.reason}</div>}
+                  {r.review_note && <div className="mt-0.5 text-xs text-gray-400">📝 {r.review_note}</div>}
+                </div>
+                <div className="flex items-center gap-2">
+                  {r.status === 'pending' ? (
+                    <>
+                      <button onClick={() => decide(r.id, true)} disabled={busy === r.id} className="rounded-md bg-emerald-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50">
+                        {busy === r.id ? '…' : 'Approve'}
+                      </button>
+                      <button onClick={() => decide(r.id, false)} disabled={busy === r.id} className="rounded-md border border-gray-200 px-2.5 py-1 text-xs text-gray-500 hover:bg-gray-100 disabled:opacity-50">Reject</button>
+                    </>
+                  ) : (
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${r.status === 'approved' ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-700'}`}>
+                      {r.status === 'approved' ? 'Approved ✓' : 'Rejected'}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/attendance/layout.tsx
+++ b/src/app/attendance/layout.tsx
@@ -11,6 +11,7 @@ const TABS = [
   { href: '/attendance/report', label: 'Report' },
   { href: '/attendance/offday', label: 'Off-day' },
   { href: '/attendance/leave', label: 'Off-day req' },
+  { href: '/attendance/halfday-req', label: 'Half-day req' },
   { href: '/attendance/advance', label: 'Advance' },
   { href: '/attendance/mc', label: 'MC' },
   { href: '/attendance/settings', label: 'Settings' },

--- a/src/components/CheckinV2.tsx
+++ b/src/components/CheckinV2.tsx
@@ -22,6 +22,7 @@ function fmtTime(t: string | null | undefined): string {
 }
 
 type OffReq = { id: string; date_from: string; date_to: string; reason: string | null; status: string; review_note: string | null; created_at: string };
+type HalfReq = { id: string; date_from: string; date_to: string; half: string; reason: string | null; status: string; review_note: string | null; created_at: string };
 
 // 'YYYY-MM-DD' -> '15 Jun'
 function fmtDate(d: string): string {
@@ -79,6 +80,14 @@ export default function CheckinV2() {
   const [offBusy, setOffBusy] = useState(false);
   const [offMsg, setOffMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
   const [myOff, setMyOff] = useState<OffReq[]>([]);
+  const [showHalf, setShowHalf] = useState(false);
+  const [halfFrom, setHalfFrom] = useState('');
+  const [halfTo, setHalfTo] = useState('');
+  const [halfWhich, setHalfWhich] = useState<'AM' | 'PM'>('PM');
+  const [halfReason, setHalfReason] = useState('');
+  const [halfBusy, setHalfBusy] = useState(false);
+  const [halfMsg, setHalfMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  const [myHalf, setMyHalf] = useState<HalfReq[]>([]);
   const [showAdv, setShowAdv] = useState(false);
   const [advAmount, setAdvAmount] = useState('');
   const [advReason, setAdvReason] = useState('');
@@ -122,6 +131,16 @@ export default function CheckinV2() {
   }, [email]);
 
   useEffect(() => { if (email) loadOff(); }, [email, loadOff]);
+
+  const loadHalf = useCallback(async () => {
+    if (!email) return;
+    const { data } = await supabase.from('halfday_requests')
+      .select('id,date_from,date_to,half,reason,status,review_note,created_at')
+      .eq('staff_email', email).order('created_at', { ascending: false }).limit(8);
+    setMyHalf((data ?? []) as HalfReq[]);
+  }, [email]);
+
+  useEffect(() => { if (email) loadHalf(); }, [email, loadHalf]);
 
   const loadAdv = useCallback(async () => {
     if (!email) return;
@@ -216,6 +235,20 @@ export default function CheckinV2() {
     if (error) setOffMsg({ kind: 'err', text: error.message });
     else { setOffMsg({ kind: 'ok', text: 'Off-day request sent ✓ — waiting for approval.' }); setOffFrom(''); setOffTo(''); setOffReason(''); loadOff(); }
     setOffBusy(false);
+  };
+
+  const submitHalf = async () => {
+    if (!email) return;
+    if (!halfFrom || !halfTo) { setHalfMsg({ kind: 'err', text: 'Pick the start and end dates.' }); return; }
+    if (halfFrom > halfTo) { setHalfMsg({ kind: 'err', text: 'The "From" date is after the "To" date.' }); return; }
+    if (halfFrom < klDatePlus(2)) { setHalfMsg({ kind: 'err', text: 'Half-day requests must be made at least 2 days in advance.' }); return; }
+    setHalfBusy(true); setHalfMsg(null);
+    const { error } = await supabase.from('halfday_requests').insert({
+      staff_email: email, date_from: halfFrom, date_to: halfTo, half: halfWhich, reason: halfReason || null,
+    });
+    if (error) setHalfMsg({ kind: 'err', text: error.message });
+    else { setHalfMsg({ kind: 'ok', text: 'Half-day request sent ✓ — waiting for approval.' }); setHalfFrom(''); setHalfTo(''); setHalfReason(''); loadHalf(); }
+    setHalfBusy(false);
   };
 
   const submitAdv = async () => {
@@ -370,6 +403,67 @@ export default function CheckinV2() {
                 <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <div className="text-slate-800">{r.date_from === r.date_to ? fmtDate(r.date_from) : `${fmtDate(r.date_from)} – ${fmtDate(r.date_to)}`}</div>
+                    {r.reason && <div className="truncate text-xs text-slate-400">{r.reason}</div>}
+                  </div>
+                  <span className={offStatusChip(r.status)}>{offStatusLabel(r.status)}</span>
+                </div>
+                {r.review_note && (
+                  <div className={`mt-1 rounded-md px-2 py-1 text-xs ${(r.status || '').toLowerCase() === 'rejected' ? 'bg-rose-50 text-rose-700' : 'bg-emerald-50 text-emerald-700'}`}>
+                    {(r.status || '').toLowerCase() === 'rejected' ? 'Reason: ' : 'Note: '}{r.review_note}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Request half day */}
+      <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <button onClick={() => setShowHalf((v) => !v)} className="flex w-full items-center justify-between text-sm font-medium text-slate-700">
+          <span>🕧 Request half day</span>
+          <span className="text-slate-400">{showHalf ? '−' : '+'}</span>
+        </button>
+        {showHalf && (
+          <div className="mt-3 space-y-2">
+            <div className="grid grid-cols-2 gap-2">
+              <button onClick={() => setHalfWhich('AM')} className={`rounded-md border px-2 py-1.5 text-xs font-medium ${halfWhich === 'AM' ? 'border-brand-700 bg-brand-50 text-brand-800' : 'border-slate-300 text-slate-500'}`}>Morning · 9:30–1:30</button>
+              <button onClick={() => setHalfWhich('PM')} className={`rounded-md border px-2 py-1.5 text-xs font-medium ${halfWhich === 'PM' ? 'border-brand-700 bg-brand-50 text-brand-800' : 'border-slate-300 text-slate-500'}`}>Afternoon · 1:30–6:00</button>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="text-xs text-slate-500">From
+                <input type="date" value={halfFrom} min={klDatePlus(2)} onChange={(e) => setHalfFrom(e.target.value)} className="mt-0.5 block w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm" />
+              </label>
+              <label className="text-xs text-slate-500">To
+                <input type="date" value={halfTo} min={halfFrom || klDatePlus(2)} onChange={(e) => setHalfTo(e.target.value)} className="mt-0.5 block w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm" />
+              </label>
+            </div>
+            <label className="block text-xs text-slate-500">Reason (optional)
+              <input value={halfReason} onChange={(e) => setHalfReason(e.target.value)} placeholder="e.g. clinic appointment" className="mt-0.5 block w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm" />
+            </label>
+            <button onClick={submitHalf} disabled={halfBusy} className="w-full rounded-lg bg-brand-700 py-2.5 text-sm font-semibold text-white hover:bg-brand-800 disabled:opacity-50">
+              {halfBusy ? 'Sending…' : 'Request half day'}
+            </button>
+            {halfMsg && (
+              <div className={`rounded-md border p-2 text-sm ${halfMsg.kind === 'ok' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-rose-200 bg-rose-50 text-rose-800'}`}>{halfMsg.text}</div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* My half-day requests */}
+      {myHalf.length > 0 && (
+        <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="text-sm font-medium text-slate-700">🕧 My half-day requests</div>
+          <div className="mt-2 space-y-1.5">
+            {myHalf.map((r) => (
+              <div key={r.id} className="text-sm">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="text-slate-800">
+                      <span className="mr-1 rounded bg-sky-50 px-1.5 py-0.5 text-xs font-medium text-sky-700">{r.half}</span>
+                      {r.date_from === r.date_to ? fmtDate(r.date_from) : `${fmtDate(r.date_from)} – ${fmtDate(r.date_to)}`}
+                    </div>
                     {r.reason && <div className="truncate text-xs text-slate-400">{r.reason}</div>}
                   </div>
                   <span className={offStatusChip(r.status)}>{offStatusLabel(r.status)}</span>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,8 +10,8 @@ import { supabase } from '@/lib/supabaseClient';
 
 type NavItem = { href: string; label: string; match?: string; badge?: number };
 type NotifItem = { type: string; id: string; who: string; detail: string; when: string; href: string };
-const NOTIF_ICON: Record<string, string> = { offday: '🌴', advance: '💵', mc: '📄' };
-const NOTIF_LABEL: Record<string, string> = { offday: 'off-day request', advance: 'advance request', mc: 'MC' };
+const NOTIF_ICON: Record<string, string> = { offday: '🌴', halfday: '🕧', advance: '💵', mc: '📄' };
+const NOTIF_LABEL: Record<string, string> = { offday: 'off-day request', halfday: 'half-day request', advance: 'advance request', mc: 'MC' };
 function relTime(iso: string): string {
   const m = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 60000));
   if (m < 1) return 'just now';
@@ -27,7 +27,7 @@ export default function NavBar() {
   const [email, setEmail] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [canBoard, setCanBoard] = useState<boolean>(false); // supervisor or admin -> sees Workshop
-  const [counts, setCounts] = useState<{ mc: number; offday: number; advance: number; po: number }>({ mc: 0, offday: 0, advance: 0, po: 0 });
+  const [counts, setCounts] = useState<{ mc: number; offday: number; halfday: number; advance: number; po: number }>({ mc: 0, offday: 0, halfday: 0, advance: 0, po: 0 });
   const [items, setItems] = useState<NotifItem[]>([]);
   const [bellOpen, setBellOpen] = useState(false);
   const [seenAt, setSeenAt] = useState<string>('');
@@ -61,12 +61,12 @@ export default function NavBar() {
   }, []);
 
   useEffect(() => {
-    if (!isAdmin) { setCounts({ mc: 0, offday: 0, advance: 0, po: 0 }); setItems([]); return; }
+    if (!isAdmin) { setCounts({ mc: 0, offday: 0, halfday: 0, advance: 0, po: 0 }); setItems([]); return; }
     let active = true;
     const load = async () => {
       const { data } = await supabase.rpc('notification_counts');
-      const d = (data ?? {}) as { mc?: number; offday?: number; advance?: number; po?: number };
-      if (active) setCounts({ mc: d.mc ?? 0, offday: d.offday ?? 0, advance: d.advance ?? 0, po: d.po ?? 0 });
+      const d = (data ?? {}) as { mc?: number; offday?: number; halfday?: number; advance?: number; po?: number };
+      if (active) setCounts({ mc: d.mc ?? 0, offday: d.offday ?? 0, halfday: d.halfday ?? 0, advance: d.advance ?? 0, po: d.po ?? 0 });
       const { data: it } = await supabase.rpc('notification_items');
       if (active) setItems((Array.isArray(it) ? it : []) as NotifItem[]);
     };
@@ -106,7 +106,7 @@ export default function NavBar() {
     ...(canBoard ? [{ href: '/workshop', label: 'Workshop' } as NavItem] : []),
   ];
   const adminLinks: NavItem[] = [
-    { href: '/attendance/checkin', match: '/attendance', label: 'Attendance', badge: counts.mc + counts.offday + counts.advance },
+    { href: '/attendance/checkin', match: '/attendance', label: 'Attendance', badge: counts.mc + counts.offday + counts.halfday + counts.advance },
     { href: '/niagawan/sales', match: '/niagawan', label: 'Niagawan', badge: counts.po },
     { href: '/employees', label: 'Employees' },
     // Records is a sub-tab inside the Payroll page now (PayrollTabs), not a navbar item.
@@ -205,7 +205,7 @@ export default function NavBar() {
             ) : (
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
             )}
-            {!open && isAdmin && (counts.mc + counts.offday + counts.advance + counts.po) > 0 && (
+            {!open && isAdmin && (counts.mc + counts.offday + counts.halfday + counts.advance + counts.po) > 0 && (
               <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-rose-500" />
             )}
           </button>


### PR DESCRIPTION
Mirrors the off-day flow for half-days: staff request card (AM/PM) in CheckinV2 + my-requests list, new /attendance/halfday-req admin approval tab, NavBar badge/bell (🕧). DB (halfday_requests + RLS + approve/reject_halfday + notify trigger + counts/items) already applied. tsc passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)