### PR TITLE
fix(intake): note not sent (stale closure — missing dep)

### DIFF
--- a/src/app/intake/page.tsx
+++ b/src/app/intake/page.tsx
@@ -82,7 +82,7 @@ export default function IntakePage() {
         setPhase('error');
       }
     }, 3000);
-  }, [plate, model, phone]);
+  }, [plate, model, phone, note]);
 
   const reset = () => { setPlate(''); setModel(''); setPhone(''); setNote(''); setInvNo(null); setErrMsg(null); setHistory(null); setShowDetails(false); setPhase('form'); };
 


### PR DESCRIPTION
save() omitted note from its dependency array, so it captured a stale empty note and sent p_note='' (remark stayed null, no invoice line). Add note to the deps. tsc passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)