### PR TITLE
pnl(staff meals): show food portions instead of restaurant

### DIFF
--- a/src/app/niagawan/pnl/page.tsx
+++ b/src/app/niagawan/pnl/page.tsx
@@ -12,7 +12,7 @@ type SaleInv = { inv: string; day: string; customer: string | null; amount: numb
 type Trade = { id: number; match: string; note: string | null };
 type Bill = { id: number; month: string; label: string; amount: number | string };
 type Pay = { staff_name: string; total_earn: number | string; epf_er: number | string | null; socso_er: number | string | null; eis_er: number | string | null };
-type Meal = { meal_date: string; amount: number | string; restaurant: string | null };
+type Meal = { meal_date: string; amount: number | string; item_count: number | null };
 
 const n = (x: unknown) => { const v = Number(x); return Number.isFinite(v) ? v : 0; };
 const rm = (x: number) => `RM ${x.toLocaleString('en-MY', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -58,7 +58,7 @@ export default function PnlPage() {
       supabase.from('v_payslip_admin_summary_v2').select('staff_name,total_earn,epf_er,socso_er,eis_er').eq('year', year).eq('month', month),
       supabase.from('pnl_settings').select('*'),
       supabase.rpc('grab_meals_month_total', { p_month: monthKey }),
-      supabase.from('grab_meals').select('meal_date,amount,restaurant').gte('meal_date', firstDay).lte('meal_date', lastDay).order('meal_date', { ascending: true }),
+      supabase.from('grab_meals').select('meal_date,amount,item_count').gte('meal_date', firstDay).lte('meal_date', lastDay).order('meal_date', { ascending: true }),
     ]);
     if (d.error) setErr(d.error.message); else setErr(null);
     setDaily((d.data ?? []) as Daily[]);
@@ -277,7 +277,7 @@ export default function PnlPage() {
           {tab === 'costs' && (
           <div className="mb-4 rounded-lg border border-gray-200 bg-white p-4">
             <div className="mb-2 flex items-center justify-between">
-              <span className="text-sm font-semibold text-gray-700">Staff meals — GrabFood <span className="font-normal text-gray-400">· {meals.length} order{meals.length === 1 ? '' : 's'} this month, auto from email receipts</span></span>
+              <span className="text-sm font-semibold text-gray-700">Staff meals — GrabFood <span className="font-normal text-gray-400">· {meals.reduce((s, m) => s + n(m.item_count), 0)} food · {meals.length} order{meals.length === 1 ? '' : 's'} this month, auto from email receipts</span></span>
               <span className="text-sm font-semibold">{rm(c.staffMeals)}</span>
             </div>
             {meals.length === 0 ? (
@@ -286,15 +286,13 @@ export default function PnlPage() {
               <div className="max-h-72 overflow-y-auto rounded border border-gray-100">
                 <table className="min-w-full text-sm">
                   <thead className="sticky top-0 bg-gray-50 text-left text-gray-500">
-                    <tr><th className="px-3 py-1.5 font-semibold">Date</th><th className="px-3 py-1.5 text-right font-semibold">Amount</th></tr>
+                    <tr><th className="px-3 py-1.5 font-semibold">Date</th><th className="px-3 py-1.5 text-right font-semibold">Food</th><th className="px-3 py-1.5 text-right font-semibold">Amount</th></tr>
                   </thead>
                   <tbody className="divide-y divide-gray-100">
                     {meals.map((mm, i) => (
                       <tr key={i}>
-                        <td className="px-3 py-1.5">
-                          <div className="text-gray-800">{fmtDate(mm.meal_date)}</div>
-                          {mm.restaurant && <div className="max-w-[18rem] truncate text-xs text-gray-400">{mm.restaurant}</div>}
-                        </td>
+                        <td className="px-3 py-1.5 text-gray-800">{fmtDate(mm.meal_date)}</td>
+                        <td className="px-3 py-1.5 text-right tabular-nums text-gray-700">{mm.item_count == null ? '—' : mm.item_count}</td>
                         <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums text-gray-700">{rm(n(mm.amount))}</td>
                       </tr>
                     ))}
@@ -302,6 +300,7 @@ export default function PnlPage() {
                   <tfoot>
                     <tr className="border-t border-gray-200 font-semibold">
                       <td className="px-3 py-1.5">Total</td>
+                      <td className="px-3 py-1.5 text-right tabular-nums">{meals.reduce((s, m) => s + n(m.item_count), 0)}</td>
                       <td className="px-3 py-1.5 text-right tabular-nums">{rm(c.staffMeals)}</td>
                     </tr>
                   </tfoot>


### PR DESCRIPTION
## What
On the P&L → **Staff meals — GrabFood** card, replace the **restaurant name** with **how many food portions** each order was (owner request).

- New **Food** column in the per-receipt table (Date · Food · Amount) + a **monthly total** of portions, and a "· N food" note in the card header.
- Count = total portions = sum of the `Nx` quantities parsed from each Grab e-receipt (e.g. `10x Nasi Ayam Hainan` = 10).

## Data plumbing (already live, not in this diff)
- `grab_meals.item_count` column added (migration `grab_meals_add_item_count`).
- `niagawan-ingest` edge fn `grabMeals` action now stores `item_count` (v21).
- **June backfilled** from the e-receipts (18 orders, 143 portions).

## Follow-up (needs Chrome on the Apps Script editor)
The deployed mailbox parser must be updated to extract the portion count for **new** receipts to auto-populate; until then new orders show "—" and can be re-backfilled. May/April history can be backfilled in the same script run.

Frontend-only diff; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)