### PR TITLE
inventory v3: add Engine Oil PO card (blank table)

### DIFF
--- a/src/app/niagawan/inventory-v3/page.tsx
+++ b/src/app/niagawan/inventory-v3/page.tsx
@@ -66,6 +66,26 @@ export default function InventoryV3Page() {
         <h2 className="text-sm font-semibold text-gray-800">PO CARD</h2>
       </div>
 
+      {/* ENGINE OIL PO */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="mb-3 text-sm font-semibold text-gray-800">ENGINE OIL PO</h2>
+        <div className="overflow-auto rounded border border-gray-100">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-left text-gray-600">
+              <tr>
+                <th className="px-3 py-2 font-semibold">No.</th>
+                <th className="px-3 py-2 font-semibold">Item Code</th>
+                <th className="px-3 py-2 font-semibold">Item Description</th>
+                <th className="px-3 py-2 text-right font-semibold">Balance</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              <tr><td colSpan={4} className="px-3 py-4 text-center text-gray-400">No items yet.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       {/* INVENTORY LIST CARD */}
       <div className="rounded-lg border border-gray-200 bg-white p-4">
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">


### PR DESCRIPTION
New "ENGINE OIL PO" card between the PO card and Inventory List card, with a blank table (No./Item Code/Item Description/Balance). 🤖 Generated with [Claude Code](https://claude.com/claude-code)