### PR TITLE
print: hide nav bar + section chrome on print

### DIFF
--- a/src/app/attendance/layout.tsx
+++ b/src/app/attendance/layout.tsx
@@ -23,12 +23,12 @@ export default function AttendanceLayout({ children }: { children: React.ReactNo
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
-      <h1 className="text-2xl font-semibold text-gray-900">Attendance</h1>
-      <p className="mt-1 mb-4 text-sm text-gray-500">
+      <h1 className="text-2xl font-semibold text-gray-900 no-print">Attendance</h1>
+      <p className="mt-1 mb-4 text-sm text-gray-500 no-print">
         New attendance system (v2) — running in parallel. The old pages stay live until this is proven.
       </p>
 
-      <div className="mb-6 flex flex-wrap gap-1 border-b border-gray-200">
+      <div className="mb-6 flex flex-wrap gap-1 border-b border-gray-200 no-print">
         {TABS.map((t) => (
           <Link
             key={t.href}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,3 +32,11 @@ body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
+
+/* Printing: drop site chrome so only the page content prints.
+   Anything tagged `.no-print` (the nav bar, section headers, tabs, on-screen
+   controls) is hidden; Tailwind's `print:hidden` works too. */
+@media print {
+  .no-print { display: none !important; }
+  body { background: #fff; }
+}


### PR DESCRIPTION
Fixes the report (and any page) printing the whole nav bar like a screenshot. The NavBar already had a `no-print` class but globals.css never defined the rule, so it did nothing. Adds `@media print { .no-print { display:none } }` and tags the Attendance heading / blurb / sub-tabs `no-print`, so a printout shows only the page content (plus the report's own title header).

Generated with Claude Code