### PR TITLE
payroll/finalize: auto-refresh attendance deductions before issuing payslips

### DIFF
--- a/src/app/api/payroll/finalize/route.ts
+++ b/src/app/api/payroll/finalize/route.ts
@@ -217,6 +217,15 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'This period is not OPEN (already finalized?)' }, { status: 400 });
     }
 
+    // Refresh unpaid-leave deductions from the LATEST attendance before issuing payslips, so a
+    // stale snapshot (attendance edited since the last "Generate") can never be finalized.
+    // The period is still OPEN here, so the write is allowed; this recomputes UNPAID + statutories
+    // and leaves manual earnings/deductions untouched.
+    const { error: syncErr } = await supabaseAdmin
+      .schema('pay_v2')
+      .rpc('sync_absent_deductions', { p_year: year, p_month: month });
+    if (syncErr) throw new Error('Could not refresh attendance deductions before finalizing: ' + syncErr.message);
+
     const rows = await fetchSummary(year, month);
     const items = await fetchItems(period.id);
     const staffMap = await fetchStaff();


### PR DESCRIPTION
From the payroll audit. Finalize now re-syncs unpaid-leave deductions from live attendance (pay_v2.sync_absent_deductions, while the period is still OPEN) before generating payslips — so a stale snapshot can't be finalized. Recomputes UNPAID + statutories; leaves manual items untouched. Verified the rebuild produces correct values for June via a rolled-back test.

Companion DB migration (already applied): list_manual_items got an admin-or-self guard, closing a confirmed cross-staff pay-detail leak.

Generated with Claude Code