### PR TITLE
payroll: Send test payslip to my email before blasting staff

### DIFF
--- a/src/app/api/payroll/send-payslips/route.ts
+++ b/src/app/api/payroll/send-payslips/route.ts
@@ -37,6 +37,9 @@ export async function POST(req: Request) {
     const { searchParams } = new URL(req.url);
     const year = Number(searchParams.get('year'));
     const month = Number(searchParams.get('month'));
+    // Test mode: send ONE email to the admin's own inbox so they can verify
+    // formatting + delivery before emailing real staff. Never sends to staff.
+    const isTest = searchParams.get('test') === '1';
     if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) {
       return NextResponse.json({ error: 'valid year & month required' }, { status: 400 });
     }
@@ -46,7 +49,7 @@ export async function POST(req: Request) {
     // Payslips only exist once a period is finalized (locked).
     const { data: period } = await supabaseAdmin.schema('pay_v2').from('periods').select('status').eq('year', year).eq('month', month).maybeSingle();
     if (!period) return NextResponse.json({ error: 'Period not found' }, { status: 404 });
-    if (period.status === 'OPEN') return NextResponse.json({ error: 'Finalize this period first — payslips have not been generated yet.' }, { status: 400 });
+    if (!isTest && period.status === 'OPEN') return NextResponse.json({ error: 'Finalize this period first — payslips have not been generated yet.' }, { status: 400 });
 
     const { data: rows, error: sErr } = await supabaseAdmin
       .schema('pay_v2').from('v_payslip_admin_summary')
@@ -58,6 +61,36 @@ export async function POST(req: Request) {
     const { data: staffData } = await supabaseAdmin.from('staff').select('email, full_name, name');
     const nameByEmail = new Map<string, string>();
     (staffData ?? []).forEach((s: { email: string; full_name: string | null; name: string | null }) => nameByEmail.set(s.email, s.full_name || s.name || s.email));
+
+    // ---- TEST MODE: one email to the admin's own inbox, using any existing payslip PDF ----
+    if (isTest) {
+      for (const r of (rows ?? []) as SummaryRow[]) {
+        const email = r.staff_email;
+        const name = nameByEmail.get(email) || r.staff_name || email;
+        const path = `${basePath}/payslips/${safe(name)}_${basePath}.pdf`;
+        const { data: file } = await supabaseAdmin.storage.from('payroll').download(path);
+        if (!file) continue;
+        const pdfBase64 = Buffer.from(await file.arrayBuffer()).toString('base64');
+        const body = `This is a TEST of the payslip email feature.\n\nAttached is the ${monthLabel} payslip for ${name}, sent only to you (${actor}) so you can confirm the formatting and delivery before emailing real staff. No staff member received this message.\n\nZordaq Auto Services`;
+        const res = await fetch(notifyUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            token: notifyToken,
+            action: 'sendMail',
+            to: actor,
+            subject: `[TEST] Payslip — ${monthLabel}`,
+            body,
+            filename: `TEST_Payslip_${safe(name)}_${basePath}.pdf`,
+            pdfBase64,
+          }),
+        });
+        const j = await res.json().catch(() => null);
+        if (!res.ok || !j?.ok) return NextResponse.json({ error: j?.error || `mail send failed (${res.status})` }, { status: 502 });
+        return NextResponse.json({ test: true, sentTo: actor, usedPayslipOf: name }, { status: 200 });
+      }
+      return NextResponse.json({ error: 'No payslip PDF found for this period to test with — finalize a period that has generated payslips first.' }, { status: 404 });
+    }
 
     const results: { email: string; status: 'sent' | 'error'; error?: string }[] = [];
 

--- a/src/app/payroll/v3/page.tsx
+++ b/src/app/payroll/v3/page.tsx
@@ -130,6 +130,21 @@ export default function PayrollV3Page() {
     finally { setBusy(''); }
   };
 
+  const sendTest = async () => {
+    if (!window.confirm(`Send a TEST payslip to your own email only? No staff will receive anything — this just lets you check the email + PDF.`)) return;
+    setBusy('Test'); setMsg(null);
+    try {
+      const tok = (await supabase.auth.getSession()).data.session?.access_token;
+      const res = await fetch(`/api/payroll/send-payslips?year=${year}&month=${month}&test=1`, {
+        method: 'POST', headers: tok ? { Authorization: `Bearer ${tok}` } : {},
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || 'Test send failed');
+      setMsg({ kind: 'ok', text: `Test sent to ${json.sentTo} (using ${json.usedPayslipOf}'s payslip). Check your inbox.` });
+    } catch (e) { setMsg({ kind: 'err', text: e instanceof Error ? e.message : String(e) }); }
+    finally { setBusy(''); }
+  };
+
   const prevMonth = () => { const d = new Date(year, month - 2, 1); setYear(d.getFullYear()); setMonth(d.getMonth() + 1); };
   const nextMonth = () => { const d = new Date(year, month, 1); setYear(d.getFullYear()); setMonth(d.getMonth() + 1); };
 
@@ -268,6 +283,9 @@ export default function PayrollV3Page() {
               </button>
             </>
           )}
+          <button onClick={sendTest} disabled={!!busy} title="Sends one payslip to your own email so you can check it before emailing staff." className="rounded-md border border-blue-300 px-3 py-2 text-sm text-blue-700 hover:bg-blue-50 disabled:opacity-50">
+            {busy === 'Test' ? 'Sending test…' : 'Send test to my email'}
+          </button>
           <button onClick={refresh} className="ml-auto rounded-md border px-3 py-2 text-sm hover:bg-gray-50">Refresh</button>
         </div>
         <p className="mt-2 text-xs text-gray-500">


### PR DESCRIPTION
Adds a safe test path to the payslip-email feature so an admin can verify formatting + delivery before emailing real staff.

- `send-payslips` route: `?test=1` sends ONE email to the caller's own address (auth.email) using any existing payslip PDF for the period, subject prefixed `[TEST]`; bypasses the OPEN-status guard (a test only needs a generated PDF) and never loops over / writes to staff or the email log.
- `/payroll/v3`: always-available "Send test to my email" button (the real "Email payslips to staff" stays locked-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
