### PR TITLE
workshop: auto-move paid cars to Done on Refresh

### DIFF
--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -152,10 +152,15 @@ export default function WorkshopBoardPage() {
   const refreshAll = useCallback(async () => {
     setSyncMsg('Refreshing…');
     await supabase.rpc('request_workshop_sync'); // board-writers trigger a Niagawan sync; others just reload
+    // Self-heal: the payment sync bulk-writes invoices in a way that skips the
+    // close-on-paid trigger, so paid cars would otherwise stay in Pending. Sweep
+    // them to Done now, then again after the sync lands fresh payment status.
+    await supabase.rpc('close_paid_job_cards');
     await load();
     setSyncMsg('Syncing with Niagawan… paid cars move to Done and new check-ins appear within a few seconds.');
-    setTimeout(() => { load(); }, 10000);
-    setTimeout(() => { load(); setSyncMsg(null); }, 25000);
+    const heal = async () => { await supabase.rpc('close_paid_job_cards'); await load(); };
+    setTimeout(heal, 10000);
+    setTimeout(() => { void heal(); setSyncMsg(null); }, 25000);
   }, [load]);
 
   const move = useCallback(async (card: Card, to: Card['status']) => {


### PR DESCRIPTION
## Problem
Fully-paid invoices weren't moving their job card to Done — some sat in **Pending** for days. Root cause: the payment sync **bulk-writes `niagawan_sale_inv` in a way that bypasses the `close_job_cards_on_paid` trigger**, so the trigger never fired for synced payments.

## Fix
- New DB RPC `public.close_paid_job_cards()` (SECURITY DEFINER, gated by `can_access('workshop')`) — sweeps any Pending card whose invoice is `status='paid'` and `amount>0` to Done. Matches by `sale_id` or `sale_inv`.
- **Guard:** `done_at IS NULL` — a card a human deliberately re-opened (e.g. warranty rework) is never snapped back to Done.
- **Refresh** (`refreshAll`) calls it at the same **0s / 10s / 25s** cadence as the existing reloads, so paid cars clear as the sync lands fresh payment status.

RM0 "paid" invoices are intentionally left alone (`amount>0` guard) — those are often opened before any charge, so may not be finished.

One-time catch-up for the 6 already-stuck cards was run separately (4 closed; 2 were RM0 and left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)