### PR TITLE
workshop: sync a board phone edit into Niagawan

### DIFF
--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -193,7 +193,23 @@ export default function WorkshopBoardPage() {
     if (p == null) return;
     const clean = p.replace(/[^\d+]/g, '');
     const { error } = await supabase.from('job_cards').update({ customer_phone: clean || null }).eq('id', card.id);
-    if (error) setErr(error.message);
+    if (error) { setErr(error.message); return; }
+    // Also push the number into the customer's Niagawan record — but only when we can
+    // resolve this card to a SINGLE Niagawan customer (exact check-in link, else a unique
+    // plate match). The NAS scraper does the actual write; here we just queue it.
+    if (clean) {
+      try {
+        const { data: cust } = await supabase.rpc('board_card_customer', { p_sale_id: card.sale_id ?? '', p_plate: card.plate });
+        const cid = (cust as { customer_id: string }[] | null)?.[0]?.customer_id;
+        if (cid) {
+          await supabase.rpc('queue_update_phone', { p_customer_id: cid, p_phone: clean });
+          setSyncMsg('Number saved — also updating it in Niagawan (a few seconds).');
+        } else {
+          setSyncMsg('Number saved on the board. (This car isn’t linked to a Niagawan customer, so it stays here only.)');
+        }
+        setTimeout(() => setSyncMsg(null), 8000);
+      } catch { /* Niagawan sync is best-effort; the local number is already saved */ }
+    }
     await load();
   }, [load]);
 


### PR DESCRIPTION
## What
Editing a card's WhatsApp number on the workshop board now **also updates that customer's phone in Niagawan** — when the card resolves to a **single** Niagawan customer.

## How
- **Resolve** card → `customer_id` via `board_card_customer(p_sale_id, p_plate)`: exact link (`intake_requests.cust_id`) first, else a **unique** plate-token match. Ambiguous/no match ⇒ stays local-only (clear message shown).
- **Queue** `queue_update_phone(customer_id, phone)` → `sync_requests(which='update-phone', payload)`; the **NAS scraper** performs the actual write.
- **Scraper handler** reads the customer's record and re-sends the **full field set** with only `phone` changed (never wipes name/email/address), idempotent, self-verifying.

## Safety / testing
- Strict `customer_id` match — never guesses on ambiguity.
- **Live-tested end-to-end** (write → verify → restore, net-zero), which also surfaced + fixed Niagawan's `0→60` phone normalization in the compare.
- Resolution coverage ~68% of current cards; the rest stay local-only (still works for the WhatsApp button).

DB objects (`sync_requests.payload`, `queue_update_phone`, `board_card_customer`) already applied; scraper already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)