### PR TITLE
workshop: auto-clear cancelled/paid-aged-out orphan cards

### DIFF
--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -156,6 +156,10 @@ export default function WorkshopBoardPage() {
     // close-on-paid trigger, so paid cars would otherwise stay in Pending. Sweep
     // them to Done now, then again after the sync lands fresh payment status.
     await supabase.rpc('close_paid_job_cards');
+    // Also self-heal orphans: a Pending card >2 days old whose invoice has vanished
+    // from BOTH the sales table and the all-years Debts snapshot was cancelled or
+    // paid-and-aged-out — no longer an active job — so archive it off the board.
+    await supabase.rpc('close_stale_orphan_cards');
     await load();
     setSyncMsg('Syncing with Niagawan… paid cars move to Done and new check-ins appear within a few seconds.');
     const heal = async () => { await supabase.rpc('close_paid_job_cards'); await load(); };


### PR DESCRIPTION
## Problem
When an invoice is **cancelled** (common) or fully **paid and aged out**, it disappears from every synced table, so no trigger or auto-heal can ever close the card — it's stuck in Pending forever (e.g. VAR1064 = cancelled invoice S2603019).

## Fix
`close_stale_orphan_cards()` (SECURITY DEFINER, `can_access('workshop')`) archives a Pending card that is:
- older than **2 days** (grace so a brand-new unpaid car not yet in the Debts snapshot is never touched), and
- has an invoice **absent from BOTH** `niagawan_sale_inv` **and** the all-years `niagawan_outstanding` (Debts) snapshot.

**Why safe:** unpaid invoices live in `niagawan_outstanding` forever, so absent-from-both ⇒ not an active unpaid job ⇒ cancelled or paid-and-gone. Reversible (archived, kept in history). Verified both current hits (VAR1064, PREVE WYQ5364) are genuinely CANCELLED via Niagawan's read-only invoice view.

Refresh calls it alongside `close_paid_job_cards`. One-time catch-up already cleared the 2 orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)