### PR TITLE
pinv: DD/MM date reading + supplier-suffix code matching

### DIFF
--- a/src/app/api/pinv/extract/route.ts
+++ b/src/app/api/pinv/extract/route.ts
@@ -52,6 +52,7 @@ function buildPrompt(categoryNames: string[], invoiceText: string): string {
     '"description" = a clean human description of the item WITHOUT the codes: item type + vehicle model + year, e.g. "CONDENSER W/DRIER JAZZ FREED CRZ 09". ' +
     '"unit_price" = the GROSS unit price as printed, BEFORE any discount. "discount" = the per-line discount as a PERCENT number (e.g. 15 if the line shows a "15%" discount column); use 0 when there is no discount. "amount" = the NET line total after discount, i.e. qty * unit_price * (1 - discount/100). ' +
     'Include every line item. ref_no is the supplier invoice number. ' +
+    'invoice_date = the invoice date as YYYY-MM-DD. IMPORTANT: dates on these Malaysian invoices are DAY/MONTH/YEAR (DD/MM/YYYY): "01/07/2026" means 1 July 2026 (day=01, month=07), NOT 7 January; "07/01/2026" means 7 January 2026. ALWAYS read the FIRST number as the day and the SECOND as the month, even when both are 12 or lower. ' +
     'do_no is the Delivery Order number for the whole invoice if one is shown (labelled D/O, D.O., DO, or D/O No.), e.g. "DO2026/03/0784" or "D2605525"; use null if there is no single header-level D/O number. ' +
     'If a field is missing use null (use 0 for discount).' +
     catLine +


### PR DESCRIPTION
Two fixes to the supplier Purchase Invoice pipeline, both found via a real invoice (GRAND AUTO INV2607/0001).

## 1. Date read as DD/MM (was US MM/DD)
The extract prompt asked for `YYYY-MM-DD` with no format hint, so the AI read Malaysian `01/07/2026` as **7 Jan** instead of **1 July**. Consequences: the "Billed?" sales-check searched the wrong month (everything false "not billed"), and the PI would book on the wrong date. Prompt now states invoices are **DD/MM/YYYY** and to read the first number as the day even when both ≤ 12.

## 2. Supplier-suffix code matching (DB migration, already applied)
The shop keys products as `<base>-<SUPPLIER>` (e.g. `9004D-42002-GRAND`) but the invoice line carries just `9004D-42002`. Strict token-equality missed it → false **"create new"** (duplicate risk). `pinv_candidates` now **falls back** to a `<line>-<SUFFIX>` match when there's no exact match (exact always wins, min length 5, hyphen boundary). Verified: `9004D-42002` → `9004D-42002-GRAND` uniquely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)