### PR TITLE
pinv review: widen line-items table (stop horizontal scroll)

### DIFF
--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -543,12 +543,14 @@ export default function ReviewInvoicePage() {
         );
       })()}
 
-      {/* Items */}
-      <div className="mb-2 flex items-center justify-between">
+      {/* Items — the line-items table has many columns; break it out of the narrow
+          max-w-6xl section column to use the fuller viewport width so it doesn't need
+          horizontal scrolling. Capped at 84rem; centered; heading matches the width. */}
+      <div style={{ width: 'min(84rem, calc(100vw - 2rem))' }} className="relative left-1/2 mb-2 flex -translate-x-1/2 items-center justify-between">
         <h2 className="text-sm font-semibold text-gray-700">Line items ({items.length}){resolving && <span className="ml-2 font-normal text-amber-600">· looking up Niagawan categories…</span>}</h2>
         {!locked && <button onClick={addRow} className="rounded-md border border-gray-300 px-2.5 py-1 text-xs text-gray-600 hover:bg-gray-50">+ Add row</button>}
       </div>
-      <div className="overflow-x-auto rounded-lg border border-gray-200">
+      <div style={{ width: 'min(84rem, calc(100vw - 2rem))' }} className="relative left-1/2 -translate-x-1/2 overflow-x-auto rounded-lg border border-gray-200">
         <table className="w-full border-collapse text-sm">
           <thead className="bg-gray-50 text-left">
             <tr>


### PR DESCRIPTION
The Purchase Invoice review table has ~9 columns and was squeezed into the Niagawan section's `max-w-6xl` column (~1068px), overflowing by ~110px → users had to scroll it left/right.

Fix: break the table (and its heading, so they align) out of that column to `width: min(84rem, calc(100vw - 2rem))`, centered (`relative left-1/2 -translate-x-1/2`). Width set via inline style to avoid Tailwind `calc` arbitrary-value pitfalls.

**Measured live in the browser before/after:** table overflow **111px → 0**, no page-level horizontal scroll; on narrow screens it uses full viewport width and the existing `overflow-x-auto` still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)