### PR TITLE
pinv: match supplier codes containing a space (oil-seal/bearing size+brand codes)

### DIFF
--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -162,8 +162,9 @@ export default function ReviewInvoicePage() {
       const map: Record<string, NiagawanMatch[]> = {};
       ((data ?? []) as Array<{ sku: string; code: string; descp: string | null; price: number | string | null }>).forEach((p) => {
         const m: NiagawanMatch = { sku: String(p.sku), code: String(p.code), descp: String(p.descp ?? ''), price: String(p.price ?? ''), bal: '' };
-        // Index the product under EVERY token of its code, so a line code matches it via that token.
-        Array.from(new Set(String(p.code ?? '').split(/[\s,]+/).map(normCode).filter(Boolean))).forEach((k) => {
+        // Index the product under its WHOLE normalised code AND every space/comma token, so a
+        // line matches whether its code is the full string ("32X52X8R POS") or one packed token.
+        Array.from(new Set([normCode(String(p.code ?? '')), ...String(p.code ?? '').split(/[\s,]+/).map(normCode)].filter(Boolean))).forEach((k) => {
           (map[k] = map[k] || []).push(m);
         });
       });


### PR DESCRIPTION
Purchase-invoice matcher missed products whose code has a space (e.g. `32X52X8R POS`, `45X70X12/19 NPS`) — it indexed product codes by space/comma tokens but normalised the invoice code into one blob, so they never met and the line fell to 'create new' despite the exact product existing.

Fix (additive — only adds correct matches):
- `pinv_candidates` RPC: also compare whole-normalised product code vs whole-normalised line code.
- `page.tsx`: index each candidate under its whole normalised code too.

Verified: the three failing lines (32X52X8R POS / 45X70X12/19 NPS / 45X62X11/18 NPS) now resolve to exactly the right product, one each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)