### PR TITLE
pinv review page: scan a part's barcode to find the product

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.58.0",
+        "barcode-detector": "^3.2.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.10",
         "leaflet": "^1.9.4",
@@ -1375,6 +1376,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2315,6 +2322,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/barcode-detector": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.2.1.tgz",
+      "integrity": "sha512-zLL7AbT9uNJBUzYpKg9v5tUA4yQGReExSi60q0g660Mj0wjUhKmN0GrUF3qELo8ITW9THzyJXdZQkXLMnsieiw==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "3.1.1"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5938,6 +5954,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
@@ -6091,6 +6119,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6460,6 +6503,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.1.tgz",
+      "integrity": "sha512-g0sPJBIubO6zLcJh1jftLPIN6xziaqLsvLgtpGKwDrEhyXXqla3E3yjFrznlr78UHIOMzbJPi0HDWKs/KgaB7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.58.0",
+    "barcode-detector": "^3.2.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.10",
     "leaflet": "^1.9.4",

--- a/src/app/niagawan/purchase/[id]/page.tsx
+++ b/src/app/niagawan/purchase/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import BarcodeScanner from '@/components/BarcodeScanner';
 
 type Pinv = {
   id: string;
@@ -73,6 +74,7 @@ export default function ReviewInvoicePage() {
   // product to a line — for code-less invoices (e.g. Tat Seng) the owner picks from the list
   // instead of creating duplicates. `picked` caches the chosen products for display.
   const [pickerLine, setPickerLine] = useState<number | null>(null);
+  const [scanLine, setScanLine] = useState<number | null>(null); // line whose barcode we're scanning
   const [pq, setPq] = useState('');
   const [presults, setPresults] = useState<NiagawanMatch[]>([]);
   const [picked, setPicked] = useState<Record<string, NiagawanMatch>>({});
@@ -442,6 +444,19 @@ export default function ReviewInvoicePage() {
 
   return (
     <div>
+      {scanLine !== null && (
+        <BarcodeScanner
+          onClose={() => setScanLine(null)}
+          onDetected={(code) => {
+            const idx = scanLine;
+            setScanLine(null);
+            // "Find & confirm": feed the scanned code into the existing product picker for that
+            // line — it shows the matching catalog product to confirm & link (via pickProduct).
+            setPickerLine(idx);
+            searchProducts(code);
+          }}
+        />
+      )}
       <div className="mb-3 flex items-center justify-between">
         <button onClick={() => router.push('/niagawan/purchase')} className="text-sm text-gray-500 hover:text-gray-900">← Back to invoices</button>
         <div className="flex items-center gap-2">
@@ -600,18 +615,25 @@ export default function ReviewInvoicePage() {
                 <tr key={idx} className="border-t border-gray-100 align-top">
                   <td className="px-2 py-1.5 text-gray-400">{idx + 1}</td>
                   <td className="px-2 py-1.5">
-                    <input disabled={locked} value={it.item_code}
-                      onChange={(e) => {
-                        // Typing a code is an explicit override: it must ALSO become the codes
-                        // list (which is what the NAS matches/creates by). Leaving stale alt
-                        // codes there made Niagawan ignore the owner's typed code (2026-06-12).
-                        const v = e.target.value;
-                        // Editing the code invalidates the live-lookup signals tied to the OLD code:
-                        // clear in_niagawan/niagawan_matches so the stale-catalog warning can't make a
-                        // false claim about an unverified/changed code.
-                        setItem(idx, { item_code: v, codes: v.trim() ? [v.trim()] : [], code_verified: null, sku_id: null, will_create: false, in_niagawan: null, niagawan_matches: null });
-                      }}
-                      className={`w-36 rounded border px-1.5 py-1 font-mono text-xs disabled:bg-transparent ${it.code_verified === false ? 'border-rose-400 bg-rose-50' : 'border-gray-200 disabled:border-transparent'}`} />
+                    <div className="flex items-start gap-1">
+                      <input disabled={locked} value={it.item_code}
+                        onChange={(e) => {
+                          // Typing a code is an explicit override: it must ALSO become the codes
+                          // list (which is what the NAS matches/creates by). Leaving stale alt
+                          // codes there made Niagawan ignore the owner's typed code (2026-06-12).
+                          const v = e.target.value;
+                          // Editing the code invalidates the live-lookup signals tied to the OLD code:
+                          // clear in_niagawan/niagawan_matches so the stale-catalog warning can't make a
+                          // false claim about an unverified/changed code.
+                          setItem(idx, { item_code: v, codes: v.trim() ? [v.trim()] : [], code_verified: null, sku_id: null, will_create: false, in_niagawan: null, niagawan_matches: null });
+                        }}
+                        className={`w-36 rounded border px-1.5 py-1 font-mono text-xs disabled:bg-transparent ${it.code_verified === false ? 'border-rose-400 bg-rose-50' : 'border-gray-200 disabled:border-transparent'}`} />
+                      {!locked && (
+                        <button type="button" onClick={() => setScanLine(idx)} aria-label="Scan barcode"
+                          title="Scan the part's barcode to find the product"
+                          className="shrink-0 rounded border border-gray-200 px-1.5 py-1 text-xs hover:bg-gray-50">📷</button>
+                      )}
+                    </div>
                     {it.code_verified === false && (
                       <div className="mt-0.5 max-w-[12rem] text-[10px] font-medium leading-tight text-rose-600" title="This code was NOT found in the invoice's text — the AI may have misread it. Check it against the PDF.">
                         ⚠ not found in PDF text — check it

--- a/src/components/BarcodeScanner.tsx
+++ b/src/components/BarcodeScanner.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+// Full-screen phone-camera barcode scanner. Uses the native BarcodeDetector API when it
+// really supports Code 128 (Android Chrome) and lazily falls back to a WASM ponyfill
+// (barcode-detector, ZXing-C++) on iOS Safari / Firefox — one code path for both.
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Detected = { rawValue: string };
+type DetectorLike = { detect(src: CanvasImageSource): Promise<Detected[]> };
+type BDCtor = {
+  new (opts?: { formats?: string[] }): DetectorLike;
+  getSupportedFormats?(): Promise<string[]>;
+};
+
+// 1D formats found on auto-parts boxes (Code 128 is the Proton/OEM one; keep a few EAN/UPC too).
+const FORMATS = ['code_128', 'code_39', 'ean_13', 'ean_8', 'upc_a', 'upc_e', 'codabar', 'itf'];
+
+async function makeDetector(): Promise<DetectorLike> {
+  const Native = (globalThis as unknown as { BarcodeDetector?: BDCtor }).BarcodeDetector;
+  if (Native) {
+    try {
+      const supported = (await Native.getSupportedFormats?.()) ?? [];
+      if (supported.includes('code_128')) return new Native({ formats: FORMATS });
+    } catch {
+      /* some browsers expose the constructor but throw — fall back to the ponyfill */
+    }
+  }
+  const mod = await import('barcode-detector/ponyfill');
+  const Ponyfill = (mod as unknown as { BarcodeDetector: BDCtor }).BarcodeDetector;
+  return new Ponyfill({ formats: FORMATS });
+}
+
+export default function BarcodeScanner({
+  onDetected,
+  onClose,
+}: {
+  onDetected: (code: string) => void;
+  onClose: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef(0);
+  // Keep the latest onDetected without restarting the camera when the parent re-renders.
+  const onDetectedRef = useRef(onDetected);
+  onDetectedRef.current = onDetected;
+
+  const [error, setError] = useState<string | null>(null);
+  const [torchable, setTorchable] = useState(false);
+  const [torchOn, setTorchOn] = useState(false);
+
+  const stop = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      setError(null);
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError('This browser can’t open the camera here. Try Chrome, or type the code by hand.');
+        return;
+      }
+      try {
+        const detector = await makeDetector();
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: { ideal: 'environment' }, width: { ideal: 1280 }, height: { ideal: 720 } },
+          audio: false,
+        });
+        if (!active) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        const video = videoRef.current;
+        if (!video) return;
+        video.srcObject = stream;
+        video.setAttribute('playsinline', 'true');
+        await video.play();
+
+        const track = stream.getVideoTracks()[0];
+        const caps = (track?.getCapabilities?.() ?? {}) as { torch?: boolean };
+        setTorchable(Boolean(caps.torch));
+
+        let busy = false;
+        const tick = async () => {
+          if (!streamRef.current) return;
+          if (!busy && video.readyState >= 2) {
+            busy = true;
+            try {
+              const codes = await detector.detect(video);
+              const value = codes[0]?.rawValue?.trim();
+              if (value) {
+                stop();
+                onDetectedRef.current(value);
+                return;
+              }
+            } catch {
+              /* transient per-frame decode error — keep scanning */
+            }
+            busy = false;
+          }
+          rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+      } catch (e) {
+        const name = (e as { name?: string })?.name;
+        if (name === 'NotAllowedError') setError('Camera permission was denied. Allow camera access, then try again.');
+        else if (name === 'NotFoundError') setError('No camera found on this device.');
+        else if (name === 'NotReadableError') setError('The camera is being used by another app. Close it and retry.');
+        else setError((e as Error)?.message ?? 'Could not start the camera.');
+      }
+    })();
+    return () => {
+      active = false;
+      stop();
+    };
+  }, [stop]);
+
+  const toggleTorch = useCallback(async () => {
+    const track = streamRef.current?.getVideoTracks()[0];
+    if (!track) return;
+    try {
+      await track.applyConstraints({ advanced: [{ torch: !torchOn }] } as unknown as MediaTrackConstraints);
+      setTorchOn((v) => !v);
+    } catch {
+      /* torch not actually applicable on this device — ignore */
+    }
+  }, [torchOn]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-black">
+      <div className="flex items-center justify-between px-4 py-3 text-white">
+        <span className="text-sm font-medium">Scan the part’s barcode</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md bg-white/15 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/25"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <div className="relative flex-1 overflow-hidden">
+        <video ref={videoRef} muted playsInline className="h-full w-full object-cover" />
+        {!error && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="h-28 w-72 max-w-[80%] rounded-lg border-2 border-white/80 shadow-[0_0_0_9999px_rgba(0,0,0,0.35)]" />
+          </div>
+        )}
+        {error && (
+          <div className="absolute inset-0 flex items-center justify-center p-6">
+            <div className="max-w-sm rounded-lg bg-white p-4 text-center text-sm text-gray-700">{error}</div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-center gap-3 px-4 py-3 text-white/80">
+        {torchable && (
+          <button
+            type="button"
+            onClick={toggleTorch}
+            className="rounded-md bg-white/15 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/25"
+          >
+            {torchOn ? '🔦 Torch off' : '🔦 Torch on'}
+          </button>
+        )}
+        <span className="text-xs">Point the rear camera at the barcode</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a per-line 📷 button on the purchase (parts-arrived) review page. Tapping it opens a full-screen phone-camera scanner; the scanned code is fed into the existing product picker so the matching Niagawan product shows for confirm & link (reuses `searchProducts`/`pickProduct` — no new match path).

Scanner: native `BarcodeDetector` where Code 128 is supported (Android Chrome), lazy WASM ponyfill fallback (`barcode-detector`, ZXing-C++) for iOS Safari / Firefox — one code path. Rear camera, torch where available, graceful permission/no-camera errors.

Only new dependency: `barcode-detector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)