### PR TITLE
Inventory v4: card management (create/delete card, supplier, add/remove products)

### DIFF
--- a/src/app/niagawan/inventory-v4/page.tsx
+++ b/src/app/niagawan/inventory-v4/page.tsx
@@ -15,8 +15,10 @@ type GroupItem = { id: number; group_id: number; sku: string; code: string | nul
 type Item = { sku: string; code: string | null; descp: string | null; balance: number | null };
 type PoSugg = { id: number; source: string | null; supplier_id: string | null; supplier_name: string | null; status: string; po_number: string | null; po_id: string | null; note: string | null };
 type PoLine = { id: number; suggestion_id: number; sku: string | null; code: string | null; descp: string | null; ordered_qty: number; received_qty: number };
+type Supplier = { creditor_id: string; name: string };
 
 const OPEN = new Set(['pending', 'approved', 'created']);
+const SHOW_CAP = 300; // catalog rows rendered at once — search to narrow
 // Round the order up to whole cartons (Gulf = 4 per carton). No carton set -> order exact units.
 function orderQty(need: number, carton: number | null): number {
   if (need <= 0) return 0;
@@ -39,6 +41,11 @@ export default function InventoryV4Page() {
   const [busyPo, setBusyPo] = useState<number | null>(null);
   const [editingLine, setEditingLine] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [suppliers, setSuppliers] = useState<Supplier[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set()); // sku set
+  const [targetGroupId, setTargetGroupId] = useState<number | ''>('');
+  const [inserting, setInserting] = useState(false);
+  const [search, setSearch] = useState('');
   const refreshPoll = useRef<ReturnType<typeof setInterval> | null>(null);
   const avgPoll = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -94,6 +101,11 @@ export default function InventoryV4Page() {
     setAvgFeed(m); setAvgAsOf(latest);
   }, []);
 
+  const loadSuppliers = useCallback(async () => {
+    const { data } = await supabase.from('niagawan_suppliers').select('creditor_id,name').order('name');
+    setSuppliers((data ?? []) as Supplier[]);
+  }, []);
+
   const PO_COLS = 'id,source,supplier_id,supplier_name,status,po_number,po_id,note';
   // Open POs (any card) -> so we don't re-suggest what's already on the way.
   const reloadPOs = useCallback(async () => {
@@ -116,8 +128,8 @@ export default function InventoryV4Page() {
   }, []);
 
   useEffect(() => {
-    if (isAdmin) { loadGroups(); loadGroupItems(); loadCatalog(); loadFreshness(); loadAvgFeed(); reloadPOs(); }
-  }, [isAdmin, loadGroups, loadGroupItems, loadCatalog, loadFreshness, loadAvgFeed, reloadPOs]);
+    if (isAdmin) { loadGroups(); loadGroupItems(); loadCatalog(); loadFreshness(); loadAvgFeed(); loadSuppliers(); reloadPOs(); }
+  }, [isAdmin, loadGroups, loadGroupItems, loadCatalog, loadFreshness, loadAvgFeed, loadSuppliers, reloadPOs]);
 
   useEffect(() => () => { if (refreshPoll.current) clearInterval(refreshPoll.current); if (avgPoll.current) clearInterval(avgPoll.current); }, []);
 
@@ -313,6 +325,89 @@ export default function InventoryV4Page() {
     await supabase.from('inventory_po_group_items').update({ [field]: value }).eq('id', id);
   }, []);
 
+  // ---------------- Group cards (add / delete / bind supplier / remove item) ----------------
+  const addGroup = useCallback(async () => {
+    const name = window.prompt('Name the new group card (e.g. GULF):');
+    if (!name || !name.trim()) return;
+    const nextSort = groups.reduce((m, g) => Math.max(m, g.sort_order), 0) + 1;
+    const { error } = await supabase.from('inventory_po_groups').insert({ name: name.trim(), sort_order: nextSort });
+    if (error) { window.alert('Could not add: ' + error.message); return; }
+    await loadGroups();
+  }, [groups, loadGroups]);
+
+  const deleteGroup = useCallback(async (id: number, name: string) => {
+    if (!window.confirm(`Delete the "${name}" card and everything in it?`)) return;
+    await supabase.from('inventory_po_groups').delete().eq('id', id);
+    await loadGroups();
+    await loadGroupItems();
+  }, [loadGroups, loadGroupItems]);
+
+  const setGroupSupplier = useCallback(async (groupId: number, creditorId: string) => {
+    const sup = suppliers.find((s) => s.creditor_id === creditorId);
+    const creditor = creditorId || null;
+    const name = sup?.name ?? null;
+    setGroups((prev) => prev.map((g) => (g.id === groupId ? { ...g, creditor_id: creditor, supplier_name: name } : g)));
+    const { error } = await supabase.from('inventory_po_groups').update({ creditor_id: creditor, supplier_name: name }).eq('id', groupId);
+    if (error) { window.alert('Could not set supplier: ' + error.message); await loadGroups(); }
+  }, [suppliers, loadGroups]);
+
+  const removeGroupItem = useCallback(async (id: number) => {
+    await supabase.from('inventory_po_group_items').delete().eq('id', id);
+    await loadGroupItems();
+  }, [loadGroupItems]);
+
+  // ---------------- Inventory list card (search / select / insert into a card) ----------------
+  // Token search: uppercase, every whitespace-split token must appear in "code descp".
+  const filtered = useMemo(() => {
+    const q = search.trim().toUpperCase();
+    if (!q) return items;
+    const tokens = q.split(/\s+/).filter(Boolean);
+    return items.filter((it) => {
+      const hay = ((it.code || '') + ' ' + (it.descp || '')).toUpperCase();
+      return tokens.every((t) => hay.includes(t));
+    });
+  }, [items, search]);
+  const shown = filtered.slice(0, SHOW_CAP);
+
+  // A new search is a new context — clear selection so Insert only ever writes visible rows.
+  useEffect(() => { setSelected(new Set()); }, [search]);
+
+  const toggleSelect = useCallback((sku: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(sku)) next.delete(sku); else next.add(sku);
+      return next;
+    });
+  }, []);
+
+  const allShownSelected = shown.length > 0 && shown.every((it) => selected.has(it.sku));
+  const toggleSelectAllShown = useCallback(() => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const everySel = shown.length > 0 && shown.every((it) => next.has(it.sku));
+      if (everySel) shown.forEach((it) => next.delete(it.sku));
+      else shown.forEach((it) => next.add(it.sku));
+      return next;
+    });
+  }, [shown]);
+
+  const insertSelected = useCallback(async () => {
+    if (!targetGroupId || selected.size === 0) return;
+    setInserting(true);
+    const rows = [...selected].map((sku) => {
+      const it = itemBySku.get(sku);
+      return { group_id: targetGroupId, sku, code: it?.code ?? null, descp: it?.descp ?? null };
+    });
+    // onConflict (group_id, sku): re-inserting an item already in the card is a no-op.
+    const { error } = await supabase
+      .from('inventory_po_group_items')
+      .upsert(rows, { onConflict: 'group_id,sku', ignoreDuplicates: true });
+    setInserting(false);
+    if (error) { window.alert('Could not insert: ' + error.message); return; }
+    setSelected(new Set());
+    await loadGroupItems();
+  }, [targetGroupId, selected, itemBySku, loadGroupItems]);
+
   if (isAdmin === null) return <div className="text-sm text-gray-500">Checking…</div>;
   if (!isAdmin) return <div className="text-sm text-gray-600">This page is for admins only.</div>;
 
@@ -352,8 +447,24 @@ export default function InventoryV4Page() {
 
         return (
           <div key={g.id} className="mb-5 rounded-lg border border-gray-200 bg-white">
-            <div className="flex items-center justify-between border-b border-gray-100 px-4 py-2.5">
-              <div className="text-sm font-semibold text-gray-800">{g.name} <span className="font-normal text-gray-400">· {g.supplier_name ?? '—'}</span></div>
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-100 px-4 py-2.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="text-sm font-semibold text-gray-800">{g.name}</div>
+                <select
+                  value={g.creditor_id ?? ''}
+                  onChange={(e) => setGroupSupplier(g.id, e.target.value)}
+                  className={`rounded-md border px-2 py-1 text-xs ${g.creditor_id ? 'border-gray-300 text-gray-800' : 'border-amber-300 bg-amber-50 text-amber-700'}`}
+                >
+                  <option value="">— choose supplier —</option>
+                  {g.creditor_id && !suppliers.some((s) => s.creditor_id === g.creditor_id) && (
+                    <option value={g.creditor_id}>{g.supplier_name ?? g.creditor_id} (not in list)</option>
+                  )}
+                  {suppliers.map((s) => (
+                    <option key={s.creditor_id} value={s.creditor_id}>{s.name}</option>
+                  ))}
+                </select>
+                <button onClick={() => deleteGroup(g.id, g.name)} title="Remove this group card" className="rounded border border-gray-200 px-2 py-0.5 text-xs text-rose-500 hover:bg-rose-50">✕ delete</button>
+              </div>
               <div className="flex items-center gap-2">
                 {need > 0 && <span className="rounded-full bg-rose-600 px-2 py-0.5 text-xs font-semibold text-white">{need} to order</span>}
                 {need > 0 && <button onClick={() => stageCardPO(g)} disabled={busyPo === -g.id}
@@ -371,11 +482,12 @@ export default function InventoryV4Page() {
                     <th className="px-3 py-2 text-center font-semibold" title="Average monthly units sold (3-month). Type it, or use Calculate average (coming).">Avg/mo</th>
                     <th className="px-3 py-2 text-center font-semibold" title="Stock to keep = avg × 3. Editable.">Keep-level</th>
                     <th className="px-3 py-2 text-right font-semibold" title="Keep-level − stock − on-order, rounded up to cartons">Order</th>
+                    <th className="px-3 py-2"></th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100">
                   {rows.length === 0 ? (
-                    <tr><td colSpan={6} className="px-3 py-4 text-center text-gray-400">No items in this card.</td></tr>
+                    <tr><td colSpan={7} className="px-3 py-4 text-center text-gray-400">No items in this card.</td></tr>
                   ) : rows.map((gi) => {
                     const live = itemBySku.get(gi.sku);
                     const code = live?.code ?? gi.code ?? '—';
@@ -388,7 +500,7 @@ export default function InventoryV4Page() {
                     const onOrder = code !== '—' ? onOrderByCode.get(code) ?? 0 : 0;
                     const order = keep != null && stock != null ? orderQty(keep - stock - onOrder, gi.carton_size) : null;
                     return (
-                      <tr key={gi.id} className={order && order > 0 ? 'bg-rose-50' : ''}>
+                      <tr key={gi.id} className={`group ${order && order > 0 ? 'bg-rose-50' : ''}`}>
                         <td className="whitespace-nowrap px-3 py-1.5 font-mono text-xs text-gray-900">{code}</td>
                         <td className="px-3 py-1.5 text-gray-700">{name}</td>
                         <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums text-gray-700">{stock == null ? '—' : stock}</td>
@@ -412,6 +524,9 @@ export default function InventoryV4Page() {
                             : <span className="text-xs text-emerald-600">ok</span>}
                           {onOrder > 0 && <div className="text-[10px] text-sky-600">{onOrder} on order</div>}
                         </td>
+                        <td className="px-3 py-1.5 text-right">
+                          <button onClick={() => removeGroupItem(gi.id)} title="Remove from this card" className="rounded px-1 text-xs text-rose-400 opacity-40 transition hover:bg-rose-50 hover:text-rose-600 group-hover:opacity-100">✕</button>
+                        </td>
                       </tr>
                     );
                   })}
@@ -421,6 +536,11 @@ export default function InventoryV4Page() {
           </div>
         );
       })}
+
+      {/* Add a new group card */}
+      <button onClick={addGroup} className="mb-5 w-full rounded-lg border border-dashed border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-600 hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700">
+        + Add a new card
+      </button>
 
       {/* READY FOR PO — staged drafts awaiting approval */}
       {poSuggs.some((s) => s.source === 'inventory-v4' && s.status === 'pending') && (
@@ -556,6 +676,91 @@ export default function InventoryV4Page() {
           </div>
         </div>
       )}
+
+      {/* INVENTORY LIST CARD — search the full catalog and add rows into a group card */}
+      <div className="mb-5 rounded-lg border border-gray-200 bg-white p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-gray-800">INVENTORY LIST CARD <span className="font-normal text-gray-400">· {items.length.toLocaleString('en-MY')} items (full catalog)</span></h2>
+          <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search code or description…" className="w-64 max-w-full rounded-md border border-gray-300 px-2 py-1 text-sm" />
+        </div>
+
+        {/* Selection action bar — appears once you tick at least one row */}
+        {selected.size > 0 && (
+          <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm">
+            <span className="font-medium text-blue-800">{selected.size} selected</span>
+            <button onClick={() => setSelected(new Set())} disabled={inserting} className="text-xs text-blue-600 underline hover:text-blue-800 disabled:opacity-50">clear</button>
+            {allShownSelected && filtered.length > SHOW_CAP && (
+              <span className="text-xs text-amber-700">first {SHOW_CAP.toLocaleString('en-MY')} of {filtered.length.toLocaleString('en-MY')} matches — narrow your search to reach the rest</span>
+            )}
+            <span className="ml-auto flex flex-wrap items-center gap-2">
+              <span className="text-gray-600">Insert into</span>
+              <select
+                value={targetGroupId}
+                onChange={(e) => setTargetGroupId(e.target.value ? Number(e.target.value) : '')}
+                disabled={inserting}
+                className="rounded-md border border-gray-300 px-2 py-1 text-sm disabled:opacity-50"
+              >
+                <option value="">Choose a card…</option>
+                {groups.length === 0 && <option value="" disabled>No cards yet — add one above</option>}
+                {groups.map((g) => (
+                  <option key={g.id} value={g.id}>{g.name}</option>
+                ))}
+              </select>
+              <button
+                onClick={insertSelected}
+                disabled={!targetGroupId || inserting}
+                className="rounded-md bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {inserting ? 'Inserting…' : (() => { const n = groups.find((g) => g.id === targetGroupId)?.name; return n ? `Insert → ${n}` : 'Insert'; })()}
+              </button>
+            </span>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-sm text-gray-500">Loading the full catalog…</div>
+        ) : (
+          <>
+            <div className="max-h-[70vh] overflow-auto rounded border border-gray-100">
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead className="sticky top-0 bg-gray-50 text-left text-gray-600">
+                  <tr>
+                    <th className="px-3 py-2">
+                      <input type="checkbox" checked={allShownSelected} onChange={toggleSelectAllShown} title="Select all shown" className="cursor-pointer" />
+                    </th>
+                    <th className="px-3 py-2 font-semibold">No.</th>
+                    <th className="px-3 py-2 font-semibold">Item Code</th>
+                    <th className="px-3 py-2 font-semibold">Item Description</th>
+                    <th className="px-3 py-2 text-right font-semibold">Balance</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {shown.map((it, i) => {
+                    const sel = selected.has(it.sku);
+                    return (
+                      <tr key={it.sku} className={sel ? 'bg-blue-50' : ''}>
+                        <td className="px-3 py-1.5">
+                          <input type="checkbox" checked={sel} onChange={() => toggleSelect(it.sku)} className="cursor-pointer" />
+                        </td>
+                        <td className="px-3 py-1.5 text-gray-400">{i + 1}</td>
+                        <td className="whitespace-nowrap px-3 py-1.5 font-mono text-xs text-gray-900">{it.code || '—'}</td>
+                        <td className="px-3 py-1.5 text-gray-700">{it.descp || '—'}</td>
+                        <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums text-gray-700">{it.balance == null ? '—' : it.balance}</td>
+                      </tr>
+                    );
+                  })}
+                  {shown.length === 0 && (
+                    <tr><td colSpan={5} className="px-3 py-4 text-center text-gray-400">No items match “{search}”.</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-1 text-xs text-gray-400">
+              Showing {shown.length.toLocaleString('en-MY')} of {filtered.length.toLocaleString('en-MY')}{filtered.length !== items.length ? ` matching (of ${items.length.toLocaleString('en-MY')} total)` : ''}{filtered.length > SHOW_CAP ? ' — search to narrow the list.' : ''}
+            </div>
+          </>
+        )}
+      </div>
 
       <p className="mt-2 text-xs text-gray-400">
         Avg/mo auto-fills from 📊 Calculate average (scans the last 3 months of sales){avgAsOf ? ` · updated ${new Date(avgAsOf).toLocaleDateString('en-MY', { day: '2-digit', month: 'short' })}` : ''}; type over any oil to override, Keep-level defaults to avg×3. “Generate PO →” on a card stages a draft; approve it and the NAS creates the PO in Niagawan.


### PR DESCRIPTION
Ports v3's group-card management into v4 (frontend only, same tables): per-card **supplier dropdown** + **✕ delete**; **✕ remove** a product from a card; **+ Add a new card**; and an **INVENTORY LIST CARD** to search the full catalog and insert products into a card.

Works for existing suppliers + newly-synced products. Suppliers-refresh (for brand-new Niagawan suppliers) is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)