### PR TITLE
Pause continuous pollers when the tab is hidden

### DIFF
--- a/src/app/add-part/page.tsx
+++ b/src/app/add-part/page.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 import BarcodeScanner from '@/components/BarcodeScanner';
 
 type OpenInv = { inv: string; sale_id: string; customer: string | null };
@@ -55,11 +56,9 @@ export default function AddPartPage() {
   }, []);
 
   useEffect(() => {
-    if (!authed || allowed !== true) return;
-    loadCars();
-    const t = setInterval(loadCars, 30000);
-    return () => clearInterval(t);
+    if (authed && allowed === true) loadCars();
   }, [authed, allowed, loadCars]);
+  useVisibleInterval(loadCars, 30000, authed && allowed === true);
 
   // Instant product search against the synced catalog (no Niagawan round-trip).
   const search = useCallback((text: string) => {

--- a/src/app/attendance/today/page.tsx
+++ b/src/app/attendance/today/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 
 type Row = {
   display_name: string | null;
@@ -72,13 +73,8 @@ export default function AttendanceTodayPage() {
     setLoading(false);
   }, []);
 
-  useEffect(() => {
-    if (isAdmin) {
-      load();
-      const id = setInterval(load, 30000);
-      return () => clearInterval(id);
-    }
-  }, [isAdmin, load]);
+  useEffect(() => { if (isAdmin) load(); }, [isAdmin, load]);
+  useVisibleInterval(load, 30000, isAdmin);
 
   // per-staff start times (for the per-person "Absent" cutoff = start + 1h)
   useEffect(() => {

--- a/src/app/niagawan/inventory-v2/page.tsx
+++ b/src/app/niagawan/inventory-v2/page.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 
 type Watch = { code: string; description: string | null; min_balance: number; category: string | null; auto_po: boolean; supplier_id: string | null; supplier_name: string | null; remarks: string | null };
 type Bal = { code: string; balance: number | null; checked_at: string | null; updated_at: string | null };
@@ -145,7 +146,7 @@ export default function InventoryV2Page() {
   const dismissSugg = useCallback(async (id: number) => { await supabase.from('po_suggestions').delete().eq('id', id); await loadSuggs(); }, [loadSuggs]);
 
   useEffect(() => { if (!isAdmin) return; loadAll(); loadNewItems(); }, [isAdmin, loadAll, loadNewItems]);
-  useEffect(() => { if (!isAdmin) return; const t = setInterval(loadSuggs, 12000); return () => clearInterval(t); }, [isAdmin, loadSuggs]);
+  useVisibleInterval(loadSuggs, 12000, isAdmin);
   useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); if (poPollRef.current) clearInterval(poPollRef.current); if (toastTimer.current) clearTimeout(toastTimer.current); }, []);
 
   const balByCode = useMemo(() => { const m = new Map<string, Bal>(); for (const b of bals) m.set(b.code, b); return m; }, [bals]);

--- a/src/app/niagawan/inventory-v3/page.tsx
+++ b/src/app/niagawan/inventory-v3/page.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 
 type Item = { sku: string; code: string | null; descp: string | null; balance: number | null };
 type Group = { id: number; name: string; sort_order: number; creditor_id: string | null; supplier_name: string | null };
@@ -194,11 +195,7 @@ export default function InventoryV3Page() {
   // and auto cross-off receipts show up. Skip the lines refresh while a qty input is focused
   // so a poll can't clobber an in-progress edit.
   const hasOpenPo = poSuggs.some((s) => s.status === 'approved' || s.status === 'created');
-  useEffect(() => {
-    if (!isAdmin || !hasOpenPo) return;
-    const t = setInterval(() => { if (editingLine != null) reloadSuggsOnly(); else reloadPOs(); }, 12000);
-    return () => clearInterval(t);
-  }, [isAdmin, hasOpenPo, editingLine, reloadSuggsOnly, reloadPOs]);
+  useVisibleInterval(() => { if (editingLine != null) reloadSuggsOnly(); else reloadPOs(); }, 12000, isAdmin && hasOpenPo);
 
   // Live lookup: sku -> catalog row (for fresh description / balance in the group cards).
   const itemBySku = useMemo(() => {

--- a/src/app/niagawan/inventory-v4/page.tsx
+++ b/src/app/niagawan/inventory-v4/page.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 
 type Group = { id: number; name: string; sort_order: number; creditor_id: string | null; supplier_name: string | null };
 type GroupItem = { id: number; group_id: number; sku: string; code: string | null; descp: string | null; carton_size: number | null; avg_monthly: number | null; keep_level: number | null };
@@ -207,11 +208,7 @@ export default function InventoryV4Page() {
 
   // While a v4 PO is being created / awaiting delivery, poll so its PO number + receipts show up.
   const hasOpenPo = poSuggs.some((s) => s.source === 'inventory-v4' && (s.status === 'approved' || s.status === 'created'));
-  useEffect(() => {
-    if (!isAdmin || !hasOpenPo) return;
-    const t = setInterval(() => { if (editingLine != null) reloadSuggsOnly(); else reloadPOs(); }, 12000);
-    return () => clearInterval(t);
-  }, [isAdmin, hasOpenPo, editingLine, reloadSuggsOnly, reloadPOs]);
+  useVisibleInterval(() => { if (editingLine != null) reloadSuggsOnly(); else reloadPOs(); }, 12000, isAdmin && hasOpenPo);
 
   // ---------------- Purchase orders ----------------
   // Stage a draft PO from a card's red rows (one line per code, skip what's already on order).

--- a/src/app/niagawan/inventory/page.tsx
+++ b/src/app/niagawan/inventory/page.tsx
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 
 type Watch = { code: string; description: string | null; min_balance: number; category: string | null; auto_po: boolean; supplier_id: string | null; supplier_name: string | null; remarks: string | null };
 type Bal = { code: string; balance: number | null; suppliers: number | null; checked_at: string | null; updated_at: string | null };
@@ -132,7 +133,7 @@ export default function NiagawanInventoryPage() {
   const dismissSugg = useCallback(async (id: number) => { await supabase.from('po_suggestions').delete().eq('id', id); await loadSuggs(); }, [loadSuggs]);
 
   useEffect(() => { if (!isAdmin) return; loadAll(); loadNewItems(); }, [isAdmin, loadAll, loadNewItems]);
-  useEffect(() => { if (!isAdmin) return; const t = setInterval(loadSuggs, 12000); return () => clearInterval(t); }, [isAdmin, loadSuggs]);
+  useVisibleInterval(loadSuggs, 12000, isAdmin);
   useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); if (poPollRef.current) clearInterval(poPollRef.current); }, []);
 
   const balByCode = useMemo(() => { const m = new Map<string, Bal>(); for (const b of bals) m.set(b.code, b); return m; }, [bals]);

--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { useVisibleInterval } from '@/lib/useVisibleInterval';
 
 type Card = {
   id: string;
@@ -140,11 +141,11 @@ export default function WorkshopBoardPage() {
 
   // Live board: refresh every 15s so every supervisor PC stays current.
   useEffect(() => {
-    if (!authed || canWrite !== true) return;
-    load();
-    const t = setInterval(load, 15000);
-    return () => clearInterval(t);
+    if (authed && canWrite === true) load();
   }, [authed, canWrite, load]);
+  // Live board refresh — paused while the tab is hidden (see hook), so a backgrounded
+  // supervisor PC stops re-fetching the whole board every 15s. Refreshes on refocus.
+  useVisibleInterval(load, 15000, authed && canWrite === true);
 
   // One refresh for the whole workshop system: pull latest payment status from Niagawan
   // (so paid cars move to Done, new check-ins appear) AND reload the board now. The same

--- a/src/lib/useVisibleInterval.ts
+++ b/src/lib/useVisibleInterval.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Like setInterval, but it only runs while the browser tab is visible, and it fires once
+ * immediately when the tab becomes visible/focused again. A backgrounded tab makes ZERO calls —
+ * this stops left-open admin/board screens from polling the DB every few seconds forever.
+ *
+ * - `enabled = false` turns the timer off entirely (e.g. until the user is authorised).
+ * - `fn` is always invoked with its latest closure (via a ref), so it can safely read changing
+ *   state/props without churning the interval. The interval is only re-created when `ms` or
+ *   `enabled` change.
+ */
+export function useVisibleInterval(fn: () => void, ms: number, enabled: boolean | null | undefined = true) {
+  const saved = useRef(fn);
+  saved.current = fn;
+  useEffect(() => {
+    if (!enabled) return;
+    const runIfVisible = () => { if (typeof document === 'undefined' || !document.hidden) saved.current(); };
+    const id = setInterval(runIfVisible, ms);
+    document.addEventListener('visibilitychange', runIfVisible);
+    window.addEventListener('focus', runIfVisible);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', runIfVisible);
+      window.removeEventListener('focus', runIfVisible);
+    };
+  }, [ms, enabled]);
+}


### PR DESCRIPTION
Part 3 of the resource-waste cleanup. Companion to #221 (which already did this for the NavBar bell).

**Problem:** seven pages ran a `setInterval` that re-fetched from Supabase every 12–30s for as long as the tab stayed open — **even when hidden/backgrounded**. The workshop board was the worst (all job cards + all debts + a phone-lookup RPC every 15s on each supervisor PC).

**Fix:** a shared `useVisibleInterval(fn, ms, enabled)` hook that only runs while the tab is visible and refreshes once on refocus. A backgrounded screen now makes **zero** calls; visible behaviour is unchanged.

Applied to:
- `workshop` (15s) · `attendance/today` (30s) · `add-part` (30s)
- `niagawan/inventory`, `inventory-v2`, `inventory-v3`, `inventory-v4` (12s)

Short-lived "wait for a scrape job to finish" pollers were left alone (they already stop themselves). `tsc --noEmit` clean.