### PR TITLE
Settings: single source (remove old tabs, redirect old URLs)

### DIFF
--- a/src/app/attendance/layout.tsx
+++ b/src/app/attendance/layout.tsx
@@ -14,7 +14,6 @@ const TABS = [
   { href: '/attendance/halfday-req', label: 'Half-day req' },
   { href: '/attendance/advance', label: 'Advance' },
   { href: '/attendance/mc', label: 'MC' },
-  { href: '/attendance/settings', label: 'Settings' },
 ];
 
 export default function AttendanceLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/attendance/settings/page.tsx
+++ b/src/app/attendance/settings/page.tsx
@@ -1,10 +1,7 @@
 // src/app/attendance/settings/page.tsx
-'use client';
+import { redirect } from 'next/navigation';
 
-import AttendanceSettings from '@/components/settings/AttendanceSettings';
-
-// Kept for the existing Attendance settings route; the same panel also lives under the
-// top-level Settings page (/settings). Both render the shared AttendanceSettings component.
-export default function AttendanceSettingsPage() {
-  return <AttendanceSettings />;
+// Settings now live on the single top-level Settings page (/settings). This old URL forwards there.
+export default function AttendanceSettingsRedirect() {
+  redirect('/settings?tab=attendance');
 }

--- a/src/app/niagawan/layout.tsx
+++ b/src/app/niagawan/layout.tsx
@@ -15,7 +15,6 @@ const TABS = [
   { href: '/niagawan/purchase', label: 'Purchase Invoice' },
   { href: '/niagawan/kiv', label: 'KIV Invoices' },
   { href: '/niagawan/pnl', label: 'P&L' },
-  { href: '/niagawan/settings', label: 'Settings' },
 ];
 
 export default function NiagawanLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/niagawan/settings/page.tsx
+++ b/src/app/niagawan/settings/page.tsx
@@ -1,10 +1,7 @@
 // src/app/niagawan/settings/page.tsx
-'use client';
+import { redirect } from 'next/navigation';
 
-import AutomationSettings from '@/components/settings/AutomationSettings';
-
-// Kept for the existing Niagawan > Settings tab; the same panel also lives under the
-// top-level Settings page (/settings). Both render the shared AutomationSettings component.
-export default function NiagawanSettingsPage() {
-  return <AutomationSettings />;
+// Settings now live on the single top-level Settings page (/settings). This old URL forwards there.
+export default function NiagawanSettingsRedirect() {
+  redirect('/settings');
 }

--- a/src/app/payroll/settings/page.tsx
+++ b/src/app/payroll/settings/page.tsx
@@ -1,16 +1,7 @@
 // src/app/payroll/settings/page.tsx
-'use client';
+import { redirect } from 'next/navigation';
 
-import PayrollTabs from '@/components/PayrollTabs';
-import PayrollItemsSettings from '@/components/settings/PayrollItemsSettings';
-
-// Kept for the existing Payroll > Settings tab; the same panel also lives under the
-// top-level Settings page (/settings). Both render the shared PayrollItemsSettings component.
-export default function PayrollSettingsPage() {
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-6">
-      <PayrollTabs />
-      <PayrollItemsSettings />
-    </div>
-  );
+// Settings now live on the single top-level Settings page (/settings). This old URL forwards there.
+export default function PayrollSettingsRedirect() {
+  redirect('/settings?tab=payroll');
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 // src/app/settings/page.tsx
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AutomationSettings from '@/components/settings/AutomationSettings';
 import PayrollItemsSettings from '@/components/settings/PayrollItemsSettings';
 import AttendanceSettings from '@/components/settings/AttendanceSettings';
@@ -17,6 +17,11 @@ const TABS: { key: TabKey; label: string }[] = [
 // Each panel is the same shared component used by its section's own settings page.
 export default function SettingsPage() {
   const [tab, setTab] = useState<TabKey>('automation');
+  // Open the tab named in ?tab= — used by the old /niagawan|payroll|attendance/settings redirects.
+  useEffect(() => {
+    const t = new URLSearchParams(window.location.search).get('tab');
+    if (t === 'automation' || t === 'payroll' || t === 'attendance') setTab(t);
+  }, []);
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">
       <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>

--- a/src/components/PayrollTabs.tsx
+++ b/src/components/PayrollTabs.tsx
@@ -9,7 +9,6 @@ import { usePathname } from 'next/navigation';
 const TABS = [
   { href: '/payroll/v3', label: 'Payroll' },
   { href: '/payroll/records', label: 'Records' },
-  { href: '/payroll/settings', label: 'Settings' },
 ];
 
 export default function PayrollTabs() {


### PR DESCRIPTION
Follow-up to #224. Removes the duplicate **Settings** entries from the Niagawan / Payroll / Attendance sub-navs, so settings live in **exactly one place** — the top-nav Settings page.

- Old `/niagawan/settings`, `/payroll/settings`, `/attendance/settings` now **redirect** to `/settings` (payroll/attendance carry `?tab=` so they land on the right tab). Any old bookmark/link still works.
- No more same-content-on-two-pages.

`tsc --noEmit` clean.