### PR TITLE
Settings > Workshop: editable WhatsApp messages

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,13 +5,15 @@ import { useEffect, useState } from 'react';
 import AutomationSettings from '@/components/settings/AutomationSettings';
 import PayrollItemsSettings from '@/components/settings/PayrollItemsSettings';
 import AttendanceSettings from '@/components/settings/AttendanceSettings';
+import WorkshopSettings from '@/components/settings/WorkshopSettings';
 import EmailSettings from '@/components/settings/EmailSettings';
 
-type TabKey = 'automation' | 'payroll' | 'attendance' | 'email';
+type TabKey = 'automation' | 'payroll' | 'attendance' | 'workshop' | 'email';
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'automation', label: 'Automation' },
   { key: 'payroll', label: 'Payroll items' },
   { key: 'attendance', label: 'Attendance' },
+  { key: 'workshop', label: 'Workshop' },
   { key: 'email', label: 'Email' },
 ];
 
@@ -22,7 +24,7 @@ export default function SettingsPage() {
   // Open the tab named in ?tab= — used by the old /niagawan|payroll|attendance/settings redirects.
   useEffect(() => {
     const t = new URLSearchParams(window.location.search).get('tab');
-    if (t === 'automation' || t === 'payroll' || t === 'attendance' || t === 'email') setTab(t);
+    if (t === 'automation' || t === 'payroll' || t === 'attendance' || t === 'workshop' || t === 'email') setTab(t);
   }, []);
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">
@@ -48,6 +50,7 @@ export default function SettingsPage() {
       {tab === 'automation' && <AutomationSettings />}
       {tab === 'payroll' && <PayrollItemsSettings />}
       {tab === 'attendance' && <AttendanceSettings />}
+      {tab === 'workshop' && <WorkshopSettings />}
       {tab === 'email' && <EmailSettings />}
     </div>
   );

--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -62,16 +62,13 @@ function waNumber(raw: string | null | undefined): string | null {
   return d.length >= 10 && d.length <= 15 ? d : null;
 }
 
-// Pre-filled WhatsApp message for a card, matched to its board status (so we never claim
-// "ready" on a car that isn't done). Wording is intentionally simple — easy to adjust.
-function waCardText(status: Card['status'], name: string, veh: string): string {
-  const msg: Record<Card['status'], string> = {
-    waiting: `Hi ${name}, we've received your ${veh} at ZORDAQ Auto Services. We'll keep you updated.`,
-    doing: `Hi ${name}, your ${veh} is being worked on at ZORDAQ Auto Services. We'll let you know once it's ready.`,
-    waiting_parts: `Hi ${name}, your ${veh} is waiting for parts at ZORDAQ Auto Services. We'll update you soon.`,
-    done: `Hi ${name}, your ${veh} is ready for collection at ZORDAQ Auto Services. Thank you!`,
-  };
-  return msg[status];
+// Customer WhatsApp wording — editable in Settings > Workshop. Only two are ever sent: the
+// "received / keep you updated" one for a car still on the board, and the "ready" one once it's
+// marked Done. Placeholders {name} (customer) and {car} (vehicle) are filled in below.
+const WA_RECEIVED_DEFAULT = "Hi {name}, we've received your {car} at ZORDAQ Auto Services. We'll keep you updated.";
+const WA_READY_DEFAULT = "Hi {name}, your {car} is ready for collection at ZORDAQ Auto Services. Thank you!";
+function fillWa(tpl: string, name: string, car: string): string {
+  return tpl.replace(/\{name\}/g, name).replace(/\{car\}/g, car);
 }
 
 export default function WorkshopBoardPage() {
@@ -85,6 +82,7 @@ export default function WorkshopBoardPage() {
   const [staffNames, setStaffNames] = useState<StaffName[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
+  const [wa, setWa] = useState<{ received: string; ready: string }>({ received: WA_RECEIVED_DEFAULT, ready: WA_READY_DEFAULT });
 
   // new-card form
   const [showForm, setShowForm] = useState(false);
@@ -108,6 +106,14 @@ export default function WorkshopBoardPage() {
           setStaffNames((names ?? []) as StaffName[]);
         }
       } else setCanWrite(false);
+    })();
+  }, []);
+
+  // Load the editable WhatsApp wording once (Settings > Workshop); falls back to the defaults.
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.from('workshop_settings').select('wa_received,wa_ready').eq('id', 1).single();
+      if (data) setWa({ received: data.wa_received || WA_RECEIVED_DEFAULT, ready: data.wa_ready || WA_READY_DEFAULT });
     })();
   }, []);
 
@@ -384,7 +390,7 @@ export default function WorkshopBoardPage() {
                         if (num) {
                           const name = c.customer || (c.sale_id ? contacts[c.sale_id]?.cust_name : null) || 'there';
                           const veh = [c.vehicle, c.plate].filter(Boolean).join(' ');
-                          const text = encodeURIComponent(waCardText(c.status === 'done' ? 'done' : 'waiting', name, veh));
+                          const text = encodeURIComponent(fillWa(c.status === 'done' ? wa.ready : wa.received, name, veh));
                           return (
                             <>
                               <a href={`https://wa.me/${num}?text=${text}`} target="_blank" rel="noopener noreferrer" className="rounded bg-green-600 px-2 py-0.5 text-xs font-semibold text-white hover:bg-green-700" title="Message the customer on WhatsApp">📲 WhatsApp</a>

--- a/src/components/settings/WorkshopSettings.tsx
+++ b/src/components/settings/WorkshopSettings.tsx
@@ -1,0 +1,94 @@
+// src/components/settings/WorkshopSettings.tsx
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+const DEF_RECEIVED = "Hi {name}, we've received your {car} at ZORDAQ Auto Services. We'll keep you updated.";
+const DEF_READY = "Hi {name}, your {car} is ready for collection at ZORDAQ Auto Services. Thank you!";
+
+export default function WorkshopSettings() {
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [received, setReceived] = useState('');
+  const [ready, setReady] = useState('');
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      setAuthed(!!data.session);
+      if (data.session) { const { data: ok } = await supabase.rpc('is_admin'); setIsAdmin(ok === true); }
+      else setIsAdmin(false);
+    })();
+  }, []);
+
+  const load = useCallback(async () => {
+    const { data } = await supabase.from('workshop_settings').select('wa_received,wa_ready').eq('id', 1).single();
+    setReceived(data?.wa_received ?? DEF_RECEIVED);
+    setReady(data?.wa_ready ?? DEF_READY);
+    setLoaded(true);
+  }, []);
+  useEffect(() => { if (isAdmin) load(); }, [isAdmin, load]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    const { error } = await supabase.from('workshop_settings')
+      .update({ wa_received: received, wa_ready: ready, updated_at: new Date().toISOString() }).eq('id', 1);
+    setSaving(false);
+    setMsg(error ? { ok: false, text: error.message } : { ok: true, text: 'Saved ✓' });
+    setTimeout(() => setMsg(null), 3000);
+  };
+
+  const preview = (t: string) => t.replace(/\{name\}/g, 'Ahmad').replace(/\{car\}/g, 'Persona JNP7801');
+
+  if (authed === null || isAdmin === null) return <div className="text-sm text-gray-500">Checking…</div>;
+  if (!authed) return <div className="text-sm text-gray-600">Please sign in.</div>;
+  if (!isAdmin) return <div className="text-sm text-gray-600">This page is for admins only.</div>;
+
+  return (
+    <div className="max-w-2xl">
+      <div className="mb-4 rounded-lg border border-gray-200 bg-white p-4">
+        <div className="text-sm font-medium text-gray-800">Customer WhatsApp messages</div>
+        <p className="mt-1 text-xs text-gray-500">
+          The wording pre-filled when you tap 📲 WhatsApp on a car. Use <b>{'{name}'}</b> for the customer and{' '}
+          <b>{'{car}'}</b> for the vehicle — they’re filled in automatically.
+        </p>
+      </div>
+
+      {!loaded ? (
+        <div className="text-sm text-gray-500">Loading…</div>
+      ) : (
+        <div className="space-y-5">
+          <div>
+            <label className="text-sm font-semibold text-gray-700">While the car is still in the shop</label>
+            <p className="mb-1 text-xs text-gray-500">Sent for any car not yet marked Done.</p>
+            <textarea value={received} onChange={(e) => setReceived(e.target.value)} rows={3}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm" />
+            <p className="mt-1 text-xs text-gray-400">Preview: {preview(received)}</p>
+          </div>
+
+          <div>
+            <label className="text-sm font-semibold text-gray-700">When the car is ready (Done)</label>
+            <p className="mb-1 text-xs text-gray-500">Sent once you mark the car Done.</p>
+            <textarea value={ready} onChange={(e) => setReady(e.target.value)} rows={3}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm" />
+            <p className="mt-1 text-xs text-gray-400">Preview: {preview(ready)}</p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button onClick={save} disabled={saving}
+              className="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-black disabled:opacity-50">
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button onClick={() => { setReceived(DEF_RECEIVED); setReady(DEF_READY); }}
+              className="rounded-md border px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">Reset to default</button>
+            {msg && <span className={`text-sm ${msg.ok ? 'text-emerald-700' : 'text-rose-700'}`}>{msg.text}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a **Workshop** tab to Settings so the owner can edit the customer WhatsApp wording.

- **Two editable messages** — matching what the board *actually* sends: one for a car **still in the shop**, one for **ready (Done)**. Uses `{name}`/`{car}` placeholders with a live preview + reset-to-default.
- Backed by a `workshop_settings` table (RLS: any signed-in user reads; admins write).
- The board now pulls the wording from settings (defaults as fallback), and the **two dead templates** ("working" / "waiting for parts", which were never sent) are **removed** to avoid confusion.

Migration `workshop_settings_wa_templates` already applied. `tsc --noEmit` clean.