### PR TITLE
Workshop mobile: visible Back pill + wrap board buttons

### DIFF
--- a/src/app/add-part/page.tsx
+++ b/src/app/add-part/page.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import BackLink from '@/components/BackLink';
 import { useVisibleInterval } from '@/lib/useVisibleInterval';
 import BarcodeScanner from '@/components/BarcodeScanner';
 
@@ -148,7 +149,7 @@ export default function AddPartPage() {
           onDetected={(code) => { setScanning(false); search(code); }}
         />
       )}
-      <a href="/workshop" className="text-sm text-gray-400 hover:text-gray-600">← Back</a>
+      <BackLink />
       <h1 className="mt-2 text-2xl font-bold text-gray-900">🔩 Part Arrived</h1>
 
       {/* 1) vehicle */}

--- a/src/app/cash-count/page.tsx
+++ b/src/app/cash-count/page.tsx
@@ -5,6 +5,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import BackLink from '@/components/BackLink';
 
 const DENOMS = [100, 50, 20, 10, 5, 1] as const;
 const rm = (n: number) => `RM ${n.toLocaleString('en-MY', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -172,7 +173,7 @@ export default function CashCountPage() {
 
   return (
     <div className="mx-auto max-w-md px-5 py-6">
-      <a href="/workshop" className="text-sm text-gray-400 hover:text-gray-600">← Back</a>
+      <BackLink />
       <h1 className="mt-2 text-2xl font-bold text-gray-900">💵 Cash Book</h1>
 
       {/* Cash Book | Petty Cash tabs */}

--- a/src/app/intake/page.tsx
+++ b/src/app/intake/page.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import BackLink from '@/components/BackLink';
 
 type Phase = 'form' | 'saving' | 'done' | 'error';
 
@@ -117,14 +118,14 @@ export default function IntakePage() {
         <button onClick={reset} className="mt-8 w-full rounded-xl bg-blue-600 px-6 py-4 text-lg font-semibold text-white hover:bg-blue-700">
           Next customer
         </button>
-        <a href="/workshop" className="mt-3 text-sm text-gray-400 underline">← Back to workshop</a>
+        <div className="mt-3 text-center"><BackLink label="Back to workshop" /></div>
       </div>
     );
   }
 
   return (
     <div className="mx-auto max-w-md px-5 py-6">
-      <a href="/workshop" className="text-sm text-gray-400 hover:text-gray-600">← Back</a>
+      <BackLink />
       <h1 className="mt-2 text-2xl font-bold text-gray-900">Car Check-in</h1>
       <p className="mt-1 text-sm text-gray-500">Please fill in your car details</p>
 

--- a/src/app/workshop/page.tsx
+++ b/src/app/workshop/page.tsx
@@ -308,7 +308,7 @@ export default function WorkshopBoardPage() {
       <div className="mb-3 flex flex-wrap items-center gap-3">
         <h1 className="text-2xl font-semibold text-gray-900">Workshop</h1>
         <span className="text-sm text-gray-400">{byCol.pending.length} car(s) in the shop</span>
-        <span className="ml-auto flex gap-2">
+        <span className="flex w-full flex-wrap gap-2 sm:ml-auto sm:w-auto">
           <button onClick={refreshAll} className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-100">🔄 Refresh</button>
           <a href="/add-part" className="rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700 hover:bg-amber-100">🔩 Part arrived</a>
           {canWrite && (

--- a/src/components/BackLink.tsx
+++ b/src/components/BackLink.tsx
@@ -1,0 +1,16 @@
+// src/components/BackLink.tsx
+import Link from 'next/link';
+
+// A clearly-visible, thumb-friendly back button — replaces the faint gray "← Back" text links
+// on the workshop sub-pages (check-in, part-arrived, cash). Bordered pill, dark text, big tap area.
+export default function BackLink({ href = '/workshop', label = 'Back' }: { href?: string; label?: string }) {
+  return (
+    <Link
+      href={href}
+      prefetch={false}
+      className="inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 active:bg-gray-100"
+    >
+      <span aria-hidden className="text-base leading-none">←</span> {label}
+    </Link>
+  );
+}


### PR DESCRIPTION
One-handed / phone polish for the supervisors' daily pages.

- **Visible Back button** — the faint `text-sm text-gray-400` "← Back" on check-in / part-arrived / cash is replaced by a shared `BackLink` **pill** (bordered, dark text, ~40px tap target). Clearly visible and easy to tap.
- **Board buttons wrap on mobile** — the top action row (Refresh / Part arrived / Customer check-in / Cash Book / + New job card) didn't wrap, so "+ New job card" was **cut off** the right edge on a phone. Now the row is full-width and wraps on mobile; unchanged on desktop.

`tsc --noEmit` clean.