### PR TITLE
Bell: attention alerts (stuck cars / low stock / newly-overdue debts)

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,8 +10,8 @@ import { supabase } from '@/lib/supabaseClient';
 
 type NavItem = { href: string; label: string; match?: string; badge?: number };
 type NotifItem = { type: string; id: string; who: string; detail: string; when: string; href: string };
-const NOTIF_ICON: Record<string, string> = { offday: '🌴', halfday: '🕧', advance: '💵', mc: '📄', po: '📦' };
-const NOTIF_LABEL: Record<string, string> = { offday: 'off-day request', halfday: 'half-day request', advance: 'advance request', mc: 'MC', po: 'purchase order' };
+const NOTIF_ICON: Record<string, string> = { offday: '🌴', halfday: '🕧', advance: '💵', mc: '📄', po: '📦', stuckcar: '🚗', debt: '🧾', lowstock: '📉' };
+const NOTIF_LABEL: Record<string, string> = { offday: 'off-day request', halfday: 'half-day request', advance: 'advance request', mc: 'MC', po: 'purchase order', stuckcar: 'in shop > 3 days', debt: 'newly overdue', lowstock: 'to restock' };
 function relTime(iso: string): string {
   const m = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 60000));
   if (m < 1) return 'just now';


### PR DESCRIPTION
Phase 1 of the notification upgrade. The admin bell now shows 3 aggregate **attention** lines alongside the pending approvals:

- 🚗 **Cars in the shop > 3 days** → tap to the board
- 🧾 **Bills newly overdue** — only ones that crossed 7 days in the **last week** (the actionable ones; the full 279-bill history stays on the board, not screaming in the bell)
- 📉 **Items below keep-level** → tap to Inventory

Each auto-clears when the condition resolves, and re-flags when a new one appears. `notification_feed()` migration `notification_feed_add_attention_alerts` already applied; NavBar gets the icons/labels.

Next up (as discussed): cash-mismatch alert (needs the expected-cash source), then act-from-the-bell, staff bell, and browser push. `tsc --noEmit` clean.