### PR TITLE
Mechanic 2/3 positions + level-scoped sales leaderboard

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -82,7 +82,7 @@ type NewEmployee = {
   eis_enabled: boolean;
 };
 
-const POSITION_OPTIONS = ['Manager', 'Supervisor', 'Mechanic', 'Admin', 'Temporary', 'Trainer'];
+const POSITION_OPTIONS = ['Manager', 'Supervisor', 'Mechanic', 'Mechanic 2', 'Mechanic 3', 'Admin', 'Temporary', 'Trainer'];
 
 function rm(n?: number | null) {
   const v = Number(n ?? 0);

--- a/src/components/PositionAccessMatrix.tsx
+++ b/src/components/PositionAccessMatrix.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 
-const POSITIONS = ['Manager', 'Supervisor', 'Mechanic', 'Admin', 'Temporary', 'Trainer'];
+const POSITIONS = ['Manager', 'Supervisor', 'Mechanic', 'Mechanic 2', 'Mechanic 3', 'Admin', 'Temporary', 'Trainer'];
 
 const FEATURES: { key: string; label: string; note?: string }[] = [
   { key: 'checkin', label: 'Clock-in' },


### PR DESCRIPTION
Owner splits mechanics into skill levels; ranking them all together by raw sales was unfair (a senior gets the big jobs).

- **Mechanic 2 / Mechanic 3** added to the position dropdown (Employees) and the access grid. Migration `add_mechanic_levels_access` copies **Mechanic's** access rows to them (check-in only), so moving a mechanic to a level keeps exactly the same access.
- **Leaderboard now scopes by the viewer's position** (`staff_sales_board`): Mechanic 2 / Mechanic 3 see only **their own level**; Supervisor / Manager / Admin / level-1 Mechanic still see everyone.

Note: Mechanic 1 = the existing **Mechanic** (or Supervisor) — no separate option, per owner. Editable/addable positions is a follow-up. `tsc --noEmit` clean.