### PR TITLE
Phone push notifications for bell alerts (Web Push / VAPID)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-leaflet": "^5.0.0",
-        "unpdf": "^1.6.2"
+        "unpdf": "^1.6.2",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -29,6 +30,7 @@
         "@types/pdfkit": "^0.17.3",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "eslint": "^9",
         "eslint-config-next": "15.5.7",
         "tailwindcss": "^4",
@@ -1464,6 +1466,16 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -2053,6 +2065,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2263,6 +2284,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2351,6 +2384,12 @@
         }
       ]
     },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2382,6 +2421,12 @@
       "dependencies": {
         "base64-js": "^1.1.2"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -2644,7 +2689,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2742,6 +2786,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -3812,6 +3865,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3848,6 +3923,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4382,6 +4463,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4768,6 +4870,12 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4785,7 +4893,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4818,7 +4925,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5494,6 +5600,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5528,6 +5654,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -6328,6 +6460,25 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-leaflet": "^5.0.0",
-    "unpdf": "^1.6.2"
+    "unpdf": "^1.6.2",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -30,6 +31,7 @@
     "@types/pdfkit": "^0.17.3",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "eslint": "^9",
     "eslint-config-next": "15.5.7",
     "tailwindcss": "^4",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Zordaq Auto Services",
+  "short_name": "Zordaq",
+  "description": "Zordaq Auto Services — attendance, payroll & Niagawan operations.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f172a",
+  "icons": [
+    { "src": "/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+    { "src": "/icon.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
+    { "src": "/icon.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,37 @@
+/* Zordaq service worker — receives Web Push and opens the right page on tap. */
+self.addEventListener('push', (event) => {
+  let data = {};
+  try { data = event.data ? event.data.json() : {}; } catch (e) { data = {}; }
+  const title = data.title || 'Zordaq';
+  const options = {
+    body: data.body || '',
+    icon: data.icon || '/icon.png',
+    badge: '/icon.png',
+    tag: data.tag || undefined,
+    data: { url: data.url || '/' },
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || '/';
+  const path = (() => { try { return new URL(target, self.location.origin).pathname; } catch (e) { return '/'; } })();
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((wins) => {
+      // Focus an already-open Zordaq tab if we have one, otherwise open a new window.
+      for (const w of wins) {
+        if (w.url && w.url.indexOf(self.location.origin) === 0 && 'focus' in w) {
+          w.focus();
+          if ('navigate' in w) { try { w.navigate(target); } catch (e) {} }
+          return;
+        }
+      }
+      if (self.clients.openWindow) return self.clients.openWindow(path);
+    })
+  );
+});
+
+// Take control quickly so a freshly-registered SW can receive pushes without a reload.
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));

--- a/src/app/api/push/dispatch/route.ts
+++ b/src/app/api/push/dispatch/route.ts
@@ -1,0 +1,73 @@
+// src/app/api/push/dispatch/route.ts
+// Called every minute by pg_cron (net.http_post). Pushes any NEW bell alert to admin devices.
+import { NextResponse } from 'next/server';
+import { pushAdmin, loadPushSecrets, configureVapid, sendToSubscription } from '@/lib/pushServer';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+export const dynamic = 'force-dynamic';
+
+// Server-side titles for each bell item type (mirrors NavBar's NOTIF_LABEL, phrased as a heading).
+const LABEL: Record<string, string> = {
+  offday: 'Off-day request',
+  halfday: 'Half-day request',
+  advance: 'Advance request',
+  mc: 'MC request',
+  po: 'Purchase order',
+  pinv: 'Purchase invoice',
+  stuckcar: 'Cars stuck in shop',
+  debt: 'Newly overdue bills',
+  lowstock: 'Items to restock',
+};
+
+type FeedItem = { type: string; id: string; who: string; detail: string; when: string; href: string };
+
+export async function POST(req: Request) {
+  const s = await loadPushSecrets();
+
+  // Shared-secret guard (pg_cron passes it in the header).
+  const token = req.headers.get('x-dispatch-token') ?? '';
+  if (!s.push_dispatch_token || token !== s.push_dispatch_token) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  // Claim + fetch the new, recent bell items.
+  const { data: pending, error } = await pushAdmin.rpc('push_pending');
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  const items = (Array.isArray(pending) ? pending : []) as FeedItem[];
+  if (items.length === 0) return NextResponse.json({ sent: 0, items: 0 });
+
+  configureVapid(s);
+
+  // Bell content is admin-only, so only push to admins' devices.
+  const { data: adminRows } = await pushAdmin.from('staff').select('email').eq('is_admin', true);
+  const adminEmails = new Set((adminRows ?? []).map((r) => String((r as { email: string }).email).toLowerCase()));
+  const { data: allSubs } = await pushAdmin.from('push_subscriptions').select('endpoint, p256dh, auth, email');
+  const subs = (allSubs ?? []).filter((x) => adminEmails.has(String((x as { email: string }).email).toLowerCase())) as
+    (import('@/lib/pushServer').SubRow & { email: string })[];
+
+  if (subs.length === 0) return NextResponse.json({ sent: 0, items: items.length, devices: 0 });
+
+  const base = s.app_base_url ?? '';
+  let sent = 0;
+  const dead = new Set<string>();
+
+  for (const it of items) {
+    const payload = JSON.stringify({
+      title: LABEL[it.type] ?? 'Zordaq alert',
+      body: `${it.who} · ${it.detail}`,
+      url: base + (it.href || '/'),
+      tag: `${it.type}:${it.id}`,
+      icon: '/icon.png',
+    });
+    const results = await Promise.all(subs.map((sub) => sendToSubscription(sub, payload)));
+    results.forEach((r, i) => {
+      if (r.ok) sent++;
+      if (r.dead) dead.add(subs[i].endpoint);
+    });
+  }
+
+  if (dead.size) await pushAdmin.from('push_subscriptions').delete().in('endpoint', [...dead]);
+
+  return NextResponse.json({ sent, items: items.length, devices: subs.length, pruned: dead.size });
+}

--- a/src/app/api/push/test/route.ts
+++ b/src/app/api/push/test/route.ts
@@ -1,0 +1,42 @@
+// src/app/api/push/test/route.ts
+// Sends a test push to the signed-in caller's own devices (powers the "Send test" button).
+import { NextResponse } from 'next/server';
+import { createClientServer } from '@/lib/supabaseServer';
+import { pushAdmin, loadPushSecrets, configureVapid, sendToSubscription, type SubRow } from '@/lib/pushServer';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  const supa = createClientServer(req);
+  const { data: { user } } = await supa.auth.getUser();
+  if (!user?.email) return NextResponse.json({ error: 'not signed in' }, { status: 401 });
+
+  const s = await loadPushSecrets();
+  configureVapid(s);
+
+  const { data: subs } = await pushAdmin
+    .from('push_subscriptions')
+    .select('endpoint, p256dh, auth')
+    .eq('email', user.email.toLowerCase());
+  if (!subs?.length) return NextResponse.json({ error: 'This device is not subscribed yet.' }, { status: 400 });
+
+  const payload = JSON.stringify({
+    title: 'Zordaq test 🔔',
+    body: 'Push notifications are working on this device.',
+    url: '/',
+    icon: '/icon.png',
+    tag: 'test',
+  });
+
+  let sent = 0;
+  const dead: string[] = [];
+  for (const sub of subs as SubRow[]) {
+    const r = await sendToSubscription(sub, payload);
+    if (r.ok) sent++;
+    if (r.dead) dead.push(sub.endpoint);
+  }
+  if (dead.length) await pushAdmin.from('push_subscriptions').delete().in('endpoint', dead);
+
+  return NextResponse.json({ sent });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,24 +1,30 @@
 export const dynamic = 'force-dynamic';
 
 import './globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import NavBar from '@/components/NavBar';
 import Container from '@/components/Container';
 import RouteKeyed from '@/components/RouteKeyed';
+import PwaRegister from '@/components/PwaRegister';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' });
 
 export const metadata: Metadata = {
   title: 'Zordaq Auto Services',
   description: 'Zordaq Auto Services — staff attendance, payroll & Niagawan operations.',
+  manifest: '/manifest.webmanifest',
   icons: { icon: '/icon.png', apple: '/icon.png' },
+  appleWebApp: { capable: true, title: 'Zordaq', statusBarStyle: 'default' },
 };
+
+export const viewport: Viewport = { themeColor: '#0f172a' };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={inter.variable}>
       <body className="min-h-screen antialiased">
+        <PwaRegister />
         <NavBar />
         <main>
           <Container>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,14 +7,16 @@ import PayrollItemsSettings from '@/components/settings/PayrollItemsSettings';
 import AttendanceSettings from '@/components/settings/AttendanceSettings';
 import WorkshopSettings from '@/components/settings/WorkshopSettings';
 import EmailSettings from '@/components/settings/EmailSettings';
+import NotificationsSettings from '@/components/settings/NotificationsSettings';
 
-type TabKey = 'automation' | 'payroll' | 'attendance' | 'workshop' | 'email';
+type TabKey = 'automation' | 'payroll' | 'attendance' | 'workshop' | 'email' | 'notifications';
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'automation', label: 'Automation' },
   { key: 'payroll', label: 'Payroll items' },
   { key: 'attendance', label: 'Attendance' },
   { key: 'workshop', label: 'Workshop' },
   { key: 'email', label: 'Email' },
+  { key: 'notifications', label: 'Notifications' },
 ];
 
 // One place for every admin setting, with a sub nav bar switching between the panels.
@@ -24,7 +26,7 @@ export default function SettingsPage() {
   // Open the tab named in ?tab= — used by the old /niagawan|payroll|attendance/settings redirects.
   useEffect(() => {
     const t = new URLSearchParams(window.location.search).get('tab');
-    if (t === 'automation' || t === 'payroll' || t === 'attendance' || t === 'workshop' || t === 'email') setTab(t);
+    if (t === 'automation' || t === 'payroll' || t === 'attendance' || t === 'workshop' || t === 'email' || t === 'notifications') setTab(t);
   }, []);
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">
@@ -52,6 +54,7 @@ export default function SettingsPage() {
       {tab === 'attendance' && <AttendanceSettings />}
       {tab === 'workshop' && <WorkshopSettings />}
       {tab === 'email' && <EmailSettings />}
+      {tab === 'notifications' && <NotificationsSettings />}
     </div>
   );
 }

--- a/src/components/PushToggle.tsx
+++ b/src/components/PushToggle.tsx
@@ -1,0 +1,130 @@
+'use client';
+// Per-device push control: turn phone notifications on/off for THIS device, and send a test.
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+export default function PushToggle() {
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [subscribed, setSubscribed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [needsInstall, setNeedsInstall] = useState(false); // iOS Safari, not yet added to Home Screen
+
+  const refresh = useCallback(async () => {
+    const ok = typeof window !== 'undefined' && 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window;
+    setSupported(ok);
+    if (!ok) {
+      // iOS only supports web push when launched from an installed (Home Screen) app.
+      const isIOS = typeof navigator !== 'undefined' && /iphone|ipad|ipod/i.test(navigator.userAgent);
+      const standalone =
+        typeof window !== 'undefined' &&
+        (window.matchMedia('(display-mode: standalone)').matches || (navigator as unknown as { standalone?: boolean }).standalone === true);
+      if (isIOS && !standalone) setNeedsInstall(true);
+      return;
+    }
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      setSubscribed(!!sub);
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const enable = useCallback(async () => {
+    setBusy(true); setMsg(null);
+    try {
+      const perm = await Notification.requestPermission();
+      if (perm !== 'granted') { setMsg('Permission was blocked. Allow notifications for this site in your browser settings, then try again.'); setBusy(false); return; }
+      const reg = await navigator.serviceWorker.register('/sw.js');
+      await navigator.serviceWorker.ready;
+      const { data: pub, error: kErr } = await supabase.rpc('push_public_key');
+      if (kErr || !pub) { setMsg('Could not load the push key. Try again in a moment.'); setBusy(false); return; }
+      const sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(pub as string) as unknown as BufferSource });
+      const j = sub.toJSON() as { endpoint?: string; keys?: { p256dh?: string; auth?: string } };
+      const { error } = await supabase.rpc('push_subscribe', {
+        p_endpoint: j.endpoint, p_p256dh: j.keys?.p256dh, p_auth: j.keys?.auth, p_ua: navigator.userAgent,
+      });
+      if (error) { setMsg(error.message); setBusy(false); return; }
+      setSubscribed(true);
+      setMsg('On for this device. You can send a test below.');
+    } catch (e: unknown) {
+      setMsg((e as Error)?.message || 'Could not turn on notifications.');
+    }
+    setBusy(false);
+  }, []);
+
+  const disable = useCallback(async () => {
+    setBusy(true); setMsg(null);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await supabase.rpc('push_unsubscribe', { p_endpoint: sub.endpoint });
+        await sub.unsubscribe();
+      }
+      setSubscribed(false);
+      setMsg('Off for this device.');
+    } catch (e: unknown) {
+      setMsg((e as Error)?.message || 'Could not turn off notifications.');
+    }
+    setBusy(false);
+  }, []);
+
+  const sendTest = useCallback(async () => {
+    setBusy(true); setMsg(null);
+    try {
+      const tok = (await supabase.auth.getSession()).data.session?.access_token;
+      const res = await fetch('/api/push/test', { method: 'POST', headers: tok ? { Authorization: `Bearer ${tok}` } : {} });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) { setMsg(body?.error || 'Test failed.'); setBusy(false); return; }
+      setMsg(body?.sent > 0 ? 'Test sent — check your notifications.' : 'No device received it.');
+    } catch (e: unknown) {
+      setMsg((e as Error)?.message || 'Test failed.');
+    }
+    setBusy(false);
+  }, []);
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4">
+      <h2 className="text-sm font-semibold text-gray-900">Phone notifications</h2>
+      <p className="mt-1 text-xs text-gray-500">
+        Get a push on this device whenever the notification bell has a new alert — even when the app is closed. Set this up on each phone you use.
+      </p>
+
+      {needsInstall ? (
+        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          <span className="font-medium">On iPhone/iPad:</span> tap the <span className="font-medium">Share</span> button →
+          <span className="font-medium"> Add to Home Screen</span>, then open <span className="font-medium">Zordaq</span> from that icon and come back here to turn it on.
+        </div>
+      ) : supported === false ? (
+        <div className="mt-3 text-sm text-gray-500">This browser doesn&apos;t support push notifications.</div>
+      ) : (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {!subscribed ? (
+            <button onClick={enable} disabled={busy} className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50">
+              {busy ? 'Working…' : '🔔 Turn on for this phone'}
+            </button>
+          ) : (
+            <>
+              <span className="inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2.5 py-1.5 text-sm font-medium text-emerald-700">✓ On for this device</span>
+              <button onClick={sendTest} disabled={busy} className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">Send test</button>
+              <button onClick={disable} disabled={busy} className="rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700 hover:bg-rose-100 disabled:opacity-50">Turn off</button>
+            </>
+          )}
+        </div>
+      )}
+
+      {msg && <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">{msg}</div>}
+    </div>
+  );
+}

--- a/src/components/PwaRegister.tsx
+++ b/src/components/PwaRegister.tsx
@@ -1,0 +1,12 @@
+'use client';
+// Registers the service worker app-wide so pushes work regardless of which page is open.
+import { useEffect } from 'react';
+
+export default function PwaRegister() {
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => { /* ignore */ });
+    }
+  }, []);
+  return null;
+}

--- a/src/components/settings/NotificationsSettings.tsx
+++ b/src/components/settings/NotificationsSettings.tsx
@@ -1,0 +1,17 @@
+'use client';
+// Settings → Notifications tab. Per-device phone push control.
+import PushToggle from '@/components/PushToggle';
+
+export default function NotificationsSettings() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Notifications</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Turn on push notifications so bell alerts reach your phone even when the app is closed. Do this once on each device you use.
+        </p>
+      </div>
+      <PushToggle />
+    </div>
+  );
+}

--- a/src/lib/pushServer.ts
+++ b/src/lib/pushServer.ts
@@ -1,0 +1,46 @@
+// src/lib/pushServer.ts
+// Server-only helpers for sending Web Push (VAPID). Never import from a client component.
+import { createClient } from '@supabase/supabase-js';
+import webpush from 'web-push';
+
+// Service-role client — reads subscriptions + secrets, prunes dead endpoints.
+export const pushAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+);
+
+export type PushSecrets = {
+  vapid_public?: string;
+  vapid_private?: string;
+  vapid_subject?: string;
+  app_base_url?: string;
+  push_dispatch_token?: string;
+};
+
+export async function loadPushSecrets(): Promise<PushSecrets> {
+  const { data } = await pushAdmin
+    .from('app_secrets')
+    .select('name,value')
+    .in('name', ['vapid_public', 'vapid_private', 'vapid_subject', 'app_base_url', 'push_dispatch_token']);
+  const m: PushSecrets = {};
+  for (const r of (data ?? []) as { name: string; value: string }[]) (m as Record<string, string>)[r.name] = r.value;
+  return m;
+}
+
+export function configureVapid(s: PushSecrets) {
+  webpush.setVapidDetails(s.vapid_subject || 'mailto:zordaqputrajaya@gmail.com', s.vapid_public ?? '', s.vapid_private ?? '');
+}
+
+export type SubRow = { endpoint: string; p256dh: string; auth: string };
+
+// Returns { ok, dead } — dead=true means the endpoint is gone (404/410) and should be removed.
+export async function sendToSubscription(sub: SubRow, payload: string): Promise<{ ok: boolean; dead: boolean }> {
+  try {
+    await webpush.sendNotification({ endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } }, payload);
+    return { ok: true, dead: false };
+  } catch (e: unknown) {
+    const code = (e as { statusCode?: number })?.statusCode;
+    return { ok: false, dead: code === 404 || code === 410 };
+  }
+}


### PR DESCRIPTION
## What
Owner wants bell alerts to reach the phone even when the app is closed — on both Android and iPhone.

## How
Standard Web Push (VAPID), no third-party service:
- **Service worker** (`public/sw.js`) shows the notification and opens the item's page on tap. **Web app manifest** + apple-web-app meta so it's installable (required for iOS push).
- **Settings → Notifications** tab: per-device **Turn on for this phone / Send test / Turn off**. iOS shows an Add-to-Home-Screen hint (Apple only allows web push from an installed PWA).
- **Sender**: Node route `/api/push/dispatch` using the `web-push` lib, guarded by a shared secret. Pulls new bell items from `push_pending()` (dedup'd; only items newer than 20 min, so turning it on doesn't blast the existing backlog) and pushes to **admin devices only**. Auto-prunes expired (404/410) subscriptions.
- `/api/push/test` sends a test push to the caller's own devices.
- `notification_feed()` refactored to source its items from a shared `_notification_items()` helper (same output — the bell is unchanged), which the dispatcher reuses so the two can't drift.

Secrets (VAPID keypair, subject, base URL, dispatch token) live in `app_secrets` — **no Vercel env changes needed**. The per-minute **pg_cron** trigger is wired separately once this route is live in prod.

## Test
- `tsc --noEmit` + `next lint` clean
- End-to-end (subscribe → dispatch → receive) verified after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)