### PR TITLE
Owners land on the dashboard when opening the app

### DIFF
--- a/src/app/checkin/page.tsx
+++ b/src/app/checkin/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+// Explicit Check-in route — where owners' "Check-in" nav points (so it doesn't get
+// redirected to the dashboard the way "/" does). Renders the same self-service page.
+import CheckinV2 from '@/components/CheckinV2';
+
+export default function CheckinPage() {
+  return (
+    <div className="py-2">
+      <CheckinV2 />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,27 @@
 'use client';
-
+// Home. Owners are sent to their dashboard on landing; everyone else gets Check-in.
+// (Owners reach Check-in via the /checkin nav link, which doesn't redirect.)
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
 import CheckinV2 from '@/components/CheckinV2';
 
 export default function HomePage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const { data } = await supabase.rpc('my_access');
+      if (!alive) return;
+      if (data && (data as { owner?: boolean }).owner) { router.replace('/dashboard'); return; }
+      setReady(true);
+    })();
+    return () => { alive = false; };
+  }, [router]);
+
+  if (!ready) return <div className="py-8 text-center text-sm text-slate-400">Loading…</div>;
   return (
     <div className="py-2">
       <CheckinV2 />

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -135,7 +135,8 @@ export default function NavBar() {
   const mainLinks: NavItem[] = [
     // Owners get a Dashboard landing; everyone keeps Check-in.
     ...(access.owner ? [{ href: '/dashboard', label: 'Dashboard' } as NavItem] : []),
-    { href: '/', label: 'Check-in' },
+    // Owners' Check-in points at /checkin so it isn't bounced to the dashboard like "/".
+    { href: access.owner ? '/checkin' : '/', label: 'Check-in' },
     // The job board — supervisors and admins only.
     ...(canBoard ? [{ href: '/workshop', label: 'Workshop' } as NavItem] : []),
   ];


### PR DESCRIPTION
The login-callback redirect only fired on a fresh OAuth sign-in, so an owner who opened the app with an existing session landed on Check-in. Now `/` redirects owners to `/dashboard` on landing. Added a `/checkin` route and pointed owners' Check-in nav there so it doesn't bounce back; non-owners keep `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)